### PR TITLE
feat(system-network): add kernel ICMP RTT tracer and latency summary …

### DIFF
--- a/measurement-tools/performance/system-network/kernel_icmp_rtt.py
+++ b/measurement-tools/performance/system-network/kernel_icmp_rtt.py
@@ -1,0 +1,970 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Simplified ICMP RTT tracer for kernel network stack only (no OVS)
+# This tool traces ICMP packets through kernel protocol stack without OVS layer
+#
+# Usage examples:
+#   TX mode (local ping remote):
+#     sudo ./kernel_icmp_rtt.py --src-ip 192.168.1.10 --dst-ip 192.168.1.20 \
+#                               --interface eth0 --direction tx
+#
+#   RX mode (remote ping local):
+#     sudo ./kernel_icmp_rtt.py --src-ip 192.168.1.10 --dst-ip 192.168.1.20 \
+#                               --interface eth0 --direction rx
+#
+#   With latency threshold:
+#     sudo ./kernel_icmp_rtt.py --src-ip 192.168.1.10 --dst-ip 192.168.1.20 \
+#                               --interface eth0 --latency-ms 10
+#
+# Trace stages (minimal host-only, no ip_send_skb dependency):
+# TX mode (local -> remote):
+#   Path 1 (Request): ip_local_out -> dev_queue_xmit
+#   Path 2 (Reply):   __netif_receive_skb -> ip_rcv -> icmp_rcv
+#
+# RX mode (remote -> local):
+#   Path 1 (Request): __netif_receive_skb -> ip_rcv -> icmp_rcv
+#   Path 2 (Reply):   ip_local_out -> dev_queue_xmit
+
+# BCC module import with fallback
+try:
+    from bcc import BPF
+except ImportError:
+    try:
+        from bpfcc import BPF
+    except ImportError:
+        import sys
+        print("Error: Neither bcc nor bpfcc module found!")
+        if sys.version_info[0] == 3:
+            print("Please install: python3-bcc or python3-bpfcc")
+        else:
+            print("Please install: python-bcc or python2-bcc")
+        sys.exit(1)
+
+from time import sleep, strftime, time as time_time
+import argparse
+import ctypes
+import socket
+import struct
+import os
+import sys
+import datetime
+import fcntl
+
+# --- BPF Program ---
+bpf_text = """
+#define DEBUG_ENABLE %d
+
+#include <uapi/linux/ptrace.h>
+#include <net/sock.h>
+#include <bcc/proto.h>
+#include <linux/skbuff.h>
+#include <linux/icmp.h>
+#include <linux/ip.h>
+#include <linux/if_ether.h>
+#include <linux/sched.h>
+#include <linux/netdevice.h>
+
+// User-defined filters
+#define SRC_IP_FILTER 0x%x
+#define DST_IP_FILTER 0x%x
+#define LATENCY_THRESHOLD_NS %d
+#define TARGET_IFINDEX %d
+#define TRACE_DIRECTION %d  // 0 for TX, 1 for RX
+
+// Stage definitions
+// Path 1 stages: 0, 1 (TX path start/end without ip_send_skb dependency)
+// Path 2 stages: 3, 4, 5
+#define PATH1_STAGE_0    0
+#define PATH1_STAGE_1    1
+#define PATH1_STAGE_2    2  // reserved/unused
+#define PATH2_STAGE_0    3
+#define PATH2_STAGE_1    4
+#define PATH2_STAGE_2    5
+
+#define MAX_STAGES       6
+#define IFNAMSIZ         16
+#define TASK_COMM_LEN    16
+
+// Debug code points (bcc-debug-framework)
+#define CODE_PROBE_ENTRY         1
+#define CODE_INTERFACE_FILTER    2
+#define CODE_HANDLE_ENTRY        5
+#define CODE_PARSE_ENTRY         6
+#define CODE_PARSE_SUCCESS       7
+#define CODE_PARSE_IP_FILTER     8
+#define CODE_FLOW_CREATE        14
+#define CODE_FLOW_LOOKUP        15
+#define CODE_FLOW_FOUND         16
+#define CODE_FLOW_NOT_FOUND     17
+#define CODE_PERF_SUBMIT        19
+#define CODE_PARSE_HDR_FAIL     20
+#define CODE_PARSE_NOT_ICMP     21
+#define CODE_PARSE_IP_MISMATCH  22
+#define CODE_PARSE_ICMP_MISMATCH 23
+
+// Debug helpers
+BPF_HISTOGRAM(debug_stage_stats, u32);
+
+static __always_inline void debug_inc(u8 stage_id, u8 code_point) {
+    if (!DEBUG_ENABLE)
+        return;
+    u32 key = ((u32)stage_id << 8) | code_point;
+    debug_stage_stats.increment(key);
+}
+
+// Packet key structure
+struct packet_key_t {
+    __be32 sip;
+    __be32 dip;
+    u8  proto;
+    __be16 id;
+    __be16 seq;
+};
+
+// Flow data structure
+struct flow_data_t {
+    u64 ts[MAX_STAGES];
+    u64 skb_ptr[MAX_STAGES];
+    int kstack_id[MAX_STAGES];
+
+    u32 p1_pid;
+    char p1_comm[TASK_COMM_LEN];
+    char p1_ifname[IFNAMSIZ];
+
+    u32 p2_pid;
+    char p2_comm[TASK_COMM_LEN];
+    char p2_ifname[IFNAMSIZ];
+
+    u8 request_type;
+    u8 reply_type;
+
+    u8 saw_path1_start:1;
+    u8 saw_path1_end:1;
+    u8 saw_path2_start:1;
+    u8 saw_path2_end:1;
+};
+
+// Event data structure
+struct event_data_t {
+    struct packet_key_t key;
+    struct flow_data_t data;
+};
+
+// Maps
+BPF_TABLE("lru_hash", struct packet_key_t, struct flow_data_t, flow_sessions, 10240);
+BPF_STACK_TRACE(stack_traces, 10240);
+BPF_PERF_OUTPUT(events);
+BPF_PERCPU_ARRAY(event_scratch_map, struct event_data_t, 1);
+
+// Helper to check interface
+static __always_inline bool is_target_ifindex(const struct sk_buff *skb) {
+    if (TARGET_IFINDEX == 0) {
+        return true;  // No filter
+    }
+
+    struct net_device *dev = NULL;
+    int ifindex = 0;
+
+    if (bpf_probe_read_kernel(&dev, sizeof(dev), &skb->dev) < 0 || dev == NULL) {
+        return false;
+    }
+
+    if (bpf_probe_read_kernel(&ifindex, sizeof(ifindex), &dev->ifindex) < 0) {
+        return false;
+    }
+
+    return (ifindex == TARGET_IFINDEX);
+}
+
+// Parse packet key
+// expect_echo_reply: 0 -> expect ICMP_ECHO, 1 -> ICMP_ECHOREPLY
+// reverse_ips:       0 -> sip=SRC_IP_FILTER, dip=DST_IP_FILTER
+//                    1 -> sip=DST_IP_FILTER, dip=SRC_IP_FILTER
+static __always_inline int parse_packet_key(struct sk_buff *skb, struct packet_key_t *key,
+                                           u8 *icmp_type_out, int expect_echo_reply,
+                                           int reverse_ips, u8 stage_id) {
+    debug_inc(stage_id, CODE_PARSE_ENTRY);
+
+    if (skb == NULL) {
+        return 0;
+    }
+
+    unsigned char *head;
+    u16 network_header_offset;
+    u16 transport_header_offset;
+
+    if (bpf_probe_read_kernel(&head, sizeof(head), &skb->head) < 0 ||
+        bpf_probe_read_kernel(&network_header_offset, sizeof(network_header_offset), &skb->network_header) < 0 ||
+        bpf_probe_read_kernel(&transport_header_offset, sizeof(transport_header_offset), &skb->transport_header) < 0) {
+        debug_inc(stage_id, CODE_PARSE_HDR_FAIL);
+        return 0;
+    }
+
+    if (network_header_offset == (u16)~0U || network_header_offset > 4096) {
+        debug_inc(stage_id, CODE_PARSE_HDR_FAIL);
+        return 0;
+    }
+
+    struct iphdr ip;
+    if (bpf_probe_read_kernel(&ip, sizeof(ip), head + network_header_offset) < 0) {
+        debug_inc(stage_id, CODE_PARSE_HDR_FAIL);
+        return 0;
+    }
+
+    if (ip.protocol != IPPROTO_ICMP) {
+        debug_inc(stage_id, CODE_PARSE_NOT_ICMP);
+        return 0;
+    }
+
+    __be32 expected_sip = reverse_ips ? DST_IP_FILTER : SRC_IP_FILTER;
+    __be32 expected_dip = reverse_ips ? SRC_IP_FILTER : DST_IP_FILTER;
+    __be32 actual_sip = ip.saddr;
+    __be32 actual_dip = ip.daddr;
+    if (!(actual_sip == expected_sip && actual_dip == expected_dip)) {
+        debug_inc(stage_id, CODE_PARSE_IP_MISMATCH);
+        return 0;
+    }
+
+    u8 expected_icmp_type_val = expect_echo_reply ? ICMP_ECHOREPLY : ICMP_ECHO;
+
+    u8 ip_ihl = ip.ihl & 0x0F;
+    if (ip_ihl < 5) {
+        debug_inc(stage_id, CODE_PARSE_HDR_FAIL);
+        return 0;
+    }
+
+    if (transport_header_offset == 0 || transport_header_offset == (u16)~0U ||
+        transport_header_offset == network_header_offset) {
+        transport_header_offset = network_header_offset + (ip_ihl * 4);
+    }
+
+    struct icmphdr icmph;
+    if (bpf_probe_read_kernel(&icmph, sizeof(icmph), head + transport_header_offset) < 0) {
+        debug_inc(stage_id, CODE_PARSE_HDR_FAIL);
+        return 0;
+    }
+
+    if (icmph.type != expected_icmp_type_val) {
+        debug_inc(stage_id, CODE_PARSE_ICMP_MISMATCH);
+        return 0;
+    }
+
+    *icmp_type_out = icmph.type;
+    key->sip = SRC_IP_FILTER;
+    key->dip = DST_IP_FILTER;
+    key->proto = ip.protocol;
+    key->id = icmph.un.echo.id;
+    key->seq = icmph.un.echo.sequence;
+
+    debug_inc(stage_id, CODE_PARSE_SUCCESS);
+
+    return 1;
+}
+
+// Handle event
+// ctx can be either struct pt_regs* (kprobe) or tracepoint args (TRACEPOINT_PROBE)
+static __always_inline void handle_event(void *ctx, struct sk_buff *skb,
+                                         u64 current_stage_global_id,
+                                         struct packet_key_t *parsed_packet_key,
+                                         u8 actual_icmp_type) {
+    debug_inc(current_stage_global_id, CODE_HANDLE_ENTRY);
+    if (skb == NULL) {
+        return;
+    }
+
+    // Check interface for first stage of each path
+    if (current_stage_global_id == PATH2_STAGE_0 && TRACE_DIRECTION == 0) {  // TX mode reply
+        if (!is_target_ifindex(skb)) {
+            debug_inc(current_stage_global_id, CODE_INTERFACE_FILTER);
+            return;
+        }
+    }
+    if (current_stage_global_id == PATH1_STAGE_0 && TRACE_DIRECTION == 1) {  // RX mode request
+        if (!is_target_ifindex(skb)) {
+            return;
+        }
+    }
+    if (current_stage_global_id == PATH1_STAGE_1 && TRACE_DIRECTION == 0) {  // TX mode request final
+        if (!is_target_ifindex(skb)) {
+            return;
+        }
+    }
+    if (current_stage_global_id == PATH2_STAGE_2 && TRACE_DIRECTION == 1) {  // RX mode reply final
+        if (!is_target_ifindex(skb)) {
+            return;
+        }
+    }
+
+    u64 current_ts = bpf_ktime_get_ns();
+    int stack_id = stack_traces.get_stackid(ctx, BPF_F_REUSE_STACKID);
+
+    struct flow_data_t *flow_ptr;
+
+    if (current_stage_global_id == PATH1_STAGE_0) {
+        struct flow_data_t zero = {};
+        debug_inc(current_stage_global_id, CODE_FLOW_CREATE);
+        flow_ptr = flow_sessions.lookup_or_try_init(parsed_packet_key, &zero);
+    } else {
+        debug_inc(current_stage_global_id, CODE_FLOW_LOOKUP);
+        flow_ptr = flow_sessions.lookup(parsed_packet_key);
+    }
+
+    if (!flow_ptr) {
+        debug_inc(current_stage_global_id, CODE_FLOW_NOT_FOUND);
+        return;
+    }
+    debug_inc(current_stage_global_id, CODE_FLOW_FOUND);
+
+    if (flow_ptr->ts[current_stage_global_id] == 0) {
+        flow_ptr->ts[current_stage_global_id] = current_ts;
+        flow_ptr->skb_ptr[current_stage_global_id] = (u64)skb;
+        flow_ptr->kstack_id[current_stage_global_id] = stack_id;
+
+        struct net_device *dev;
+        char if_name_buffer[IFNAMSIZ];
+        __builtin_memset(if_name_buffer, 0, IFNAMSIZ);
+
+        if (bpf_probe_read_kernel(&dev, sizeof(dev), &skb->dev) == 0 && dev != NULL) {
+            bpf_probe_read_kernel_str(if_name_buffer, IFNAMSIZ, dev->name);
+        } else {
+            char unk[] = "unknown";
+            bpf_probe_read_kernel_str(if_name_buffer, sizeof(unk), unk);
+        }
+
+        if (current_stage_global_id == PATH1_STAGE_0) {
+            flow_ptr->p1_pid = bpf_get_current_pid_tgid() >> 32;
+            bpf_get_current_comm(&flow_ptr->p1_comm, sizeof(flow_ptr->p1_comm));
+            bpf_probe_read_kernel_str(flow_ptr->p1_ifname, IFNAMSIZ, if_name_buffer);
+            flow_ptr->request_type = actual_icmp_type;
+            flow_ptr->saw_path1_start = 1;
+        }
+
+        if ((TRACE_DIRECTION == 0 && current_stage_global_id == PATH1_STAGE_1) ||
+            (TRACE_DIRECTION == 1 && current_stage_global_id == PATH1_STAGE_2)) {
+            flow_ptr->saw_path1_end = 1;
+        }
+
+        if (current_stage_global_id == PATH2_STAGE_0 || current_stage_global_id == PATH2_STAGE_1) {
+            flow_ptr->p2_pid = bpf_get_current_pid_tgid() >> 32;
+            bpf_get_current_comm(&flow_ptr->p2_comm, sizeof(flow_ptr->p2_comm));
+            bpf_probe_read_kernel_str(flow_ptr->p2_ifname, IFNAMSIZ, if_name_buffer);
+            flow_ptr->reply_type = actual_icmp_type;
+            flow_ptr->saw_path2_start = 1;
+        }
+
+        if (current_stage_global_id == PATH2_STAGE_2) {
+            flow_ptr->saw_path2_end = 1;
+        }
+
+        flow_sessions.update(parsed_packet_key, flow_ptr);
+    }
+
+    // Submit event when complete
+    if (current_stage_global_id == PATH2_STAGE_2 &&
+        flow_ptr->saw_path1_start && flow_ptr->saw_path1_end &&
+        flow_ptr->saw_path2_start && flow_ptr->saw_path2_end) {
+
+        u64 rtt_start_ts = flow_ptr->ts[PATH1_STAGE_0];
+        u64 rtt_end_ts = flow_ptr->ts[PATH2_STAGE_2];
+
+        if (LATENCY_THRESHOLD_NS > 0) {
+            if (rtt_start_ts == 0 || rtt_end_ts == 0 ||
+                (rtt_end_ts - rtt_start_ts) < LATENCY_THRESHOLD_NS) {
+                return;
+            }
+        }
+
+        u32 map_key_zero = 0;
+        struct event_data_t *event_data_ptr = event_scratch_map.lookup(&map_key_zero);
+        if (!event_data_ptr) {
+            return;
+        }
+
+        event_data_ptr->key = *parsed_packet_key;
+
+        if (bpf_probe_read_kernel(&event_data_ptr->data, sizeof(event_data_ptr->data), flow_ptr) != 0) {
+            flow_sessions.delete(parsed_packet_key);
+            return;
+        }
+
+        debug_inc(current_stage_global_id, CODE_PERF_SUBMIT);
+        events.perf_submit(ctx, event_data_ptr, sizeof(*event_data_ptr));
+        flow_sessions.delete(parsed_packet_key);
+    }
+}
+
+// Probe: ip_local_out
+int kprobe__ip_local_out(struct pt_regs *ctx, struct net *net, struct sock *sk, struct sk_buff *skb) {
+    struct packet_key_t key = {};
+    u8 icmp_type = 0;
+
+    debug_inc(TRACE_DIRECTION == 0 ? PATH1_STAGE_0 : PATH2_STAGE_1, CODE_PROBE_ENTRY);
+
+    if (TRACE_DIRECTION == 0) {  // TX: request path (local -> remote ECHO)
+        if (parse_packet_key(skb, &key, &icmp_type, 0, 0, PATH1_STAGE_0)) {
+            handle_event(ctx, skb, PATH1_STAGE_0, &key, icmp_type);
+        }
+    } else {  // RX: reply path
+        if (parse_packet_key(skb, &key, &icmp_type, 1, 0, PATH2_STAGE_1)) {
+            handle_event(ctx, skb, PATH2_STAGE_1, &key, icmp_type);
+        }
+    }
+    return 0;
+}
+
+// Probe: dev_queue_xmit
+int kprobe__dev_queue_xmit(struct pt_regs *ctx, struct sk_buff *skb) {
+    struct packet_key_t key = {};
+    u8 icmp_type = 0;
+
+    debug_inc(TRACE_DIRECTION == 0 ? PATH1_STAGE_1 : PATH2_STAGE_2, CODE_PROBE_ENTRY);
+
+    if (TRACE_DIRECTION == 0) {  // TX: request path
+        if (parse_packet_key(skb, &key, &icmp_type, 0, 0, PATH1_STAGE_1)) {
+            handle_event(ctx, skb, PATH1_STAGE_1, &key, icmp_type);
+        }
+    } else {  // RX: reply path
+        if (parse_packet_key(skb, &key, &icmp_type, 1, 0, PATH2_STAGE_2)) {
+            handle_event(ctx, skb, PATH2_STAGE_2, &key, icmp_type);
+        }
+    }
+    return 0;
+}
+
+// Probe: netif_receive_skb
+// Using tracepoint for better compatibility
+// NOTE: TRACEPOINT_PROBE macro already includes return type - do NOT add 'int' prefix
+//       In tracepoint context, use 'args' instead of 'ctx'
+//
+// Fallback for old kernels without this tracepoint:
+// Replace with: int kprobe____netif_receive_skb_core(struct pt_regs *ctx, struct sk_buff *skb) {
+//
+TRACEPOINT_PROBE(net, netif_receive_skb) {
+    debug_inc(TRACE_DIRECTION == 0 ? PATH2_STAGE_0 : PATH1_STAGE_0, CODE_PROBE_ENTRY);
+
+    // Get skb from tracepoint arguments
+    struct sk_buff *skb = (struct sk_buff *)args->skbaddr;
+    if (!skb) return 0;
+
+    struct packet_key_t key = {};
+    u8 icmp_type = 0;
+
+    if (TRACE_DIRECTION == 0) {  // TX: reply path (incoming echo-reply)
+        if (parse_packet_key(skb, &key, &icmp_type, 1, 1, PATH2_STAGE_0)) {
+            handle_event(args, skb, PATH2_STAGE_0, &key, icmp_type);
+        }
+    } else {  // RX: request path (source is remote, dest is local)
+        if (parse_packet_key(skb, &key, &icmp_type, 0, 1, PATH1_STAGE_0)) {
+            handle_event(args, skb, PATH1_STAGE_0, &key, icmp_type);
+        }
+    }
+    return 0;
+}
+
+// Some kernels use netif_receive_skb_entry tracepoint; attach as fallback
+TRACEPOINT_PROBE(net, netif_receive_skb_entry) {
+    debug_inc(TRACE_DIRECTION == 0 ? PATH2_STAGE_0 : PATH1_STAGE_0, CODE_PROBE_ENTRY);
+
+    struct sk_buff *skb = (struct sk_buff *)args->skbaddr;
+    if (!skb) return 0;
+
+    struct packet_key_t key = {};
+    u8 icmp_type = 0;
+
+    if (TRACE_DIRECTION == 0) {  // TX: reply path (incoming echo-reply)
+        if (parse_packet_key(skb, &key, &icmp_type, 1, 1, PATH2_STAGE_0)) {
+            handle_event(args, skb, PATH2_STAGE_0, &key, icmp_type);
+        }
+    } else {  // RX: request path
+        // RX request (incoming echo)
+        if (parse_packet_key(skb, &key, &icmp_type, 0, 1, PATH1_STAGE_0)) {
+            handle_event(args, skb, PATH1_STAGE_0, &key, icmp_type);
+        }
+    }
+    return 0;
+}
+
+// Older kernels may miss the tracepoint; fallback kprobe
+int kprobe____netif_receive_skb_core(struct pt_regs *ctx, struct sk_buff *skb) {
+    debug_inc(TRACE_DIRECTION == 0 ? PATH2_STAGE_0 : PATH1_STAGE_0, CODE_PROBE_ENTRY);
+
+    if (!skb) return 0;
+
+    struct packet_key_t key = {};
+    u8 icmp_type = 0;
+
+    if (TRACE_DIRECTION == 0) {  // TX: reply path (incoming echo-reply)
+        if (parse_packet_key(skb, &key, &icmp_type, 1, 1, PATH2_STAGE_0)) {
+            handle_event(ctx, skb, PATH2_STAGE_0, &key, icmp_type);
+        }
+    } else {  // RX: request path
+        if (parse_packet_key(skb, &key, &icmp_type, 0, 1, PATH1_STAGE_0)) {
+            handle_event(ctx, skb, PATH1_STAGE_0, &key, icmp_type);
+        }
+    }
+    return 0;
+}
+
+// Probe: ip_rcv
+// Kernel 4.18 signature: int ip_rcv(struct sk_buff *skb, struct net_device *dev,
+//                                    struct packet_type *pt, struct net_device *orig_dev)
+int kprobe__ip_rcv(struct pt_regs *ctx, struct sk_buff *skb,
+                   struct net_device *dev, struct packet_type *pt,
+                   struct net_device *orig_dev) {
+    struct packet_key_t key = {};
+    u8 icmp_type = 0;
+
+    debug_inc(TRACE_DIRECTION == 0 ? PATH2_STAGE_1 : PATH1_STAGE_1, CODE_PROBE_ENTRY);
+
+    if (TRACE_DIRECTION == 0) {  // TX: reply path (incoming echo-reply)
+        if (parse_packet_key(skb, &key, &icmp_type, 1, 1, PATH2_STAGE_1)) {
+            handle_event(ctx, skb, PATH2_STAGE_1, &key, icmp_type);
+        }
+    } else {  // RX: request path
+        if (parse_packet_key(skb, &key, &icmp_type, 0, 1, PATH1_STAGE_1)) {
+            handle_event(ctx, skb, PATH1_STAGE_1, &key, icmp_type);
+        }
+    }
+    return 0;
+}
+
+// Probe: icmp_rcv
+int kprobe__icmp_rcv(struct pt_regs *ctx, struct sk_buff *skb) {
+    struct packet_key_t key = {};
+    u8 icmp_type = 0;
+
+    debug_inc(TRACE_DIRECTION == 0 ? PATH2_STAGE_2 : PATH1_STAGE_2, CODE_PROBE_ENTRY);
+
+    if (TRACE_DIRECTION == 0) {  // TX: reply path (incoming echo-reply)
+        if (parse_packet_key(skb, &key, &icmp_type, 1, 1, PATH2_STAGE_2)) {
+            handle_event(ctx, skb, PATH2_STAGE_2, &key, icmp_type);
+        }
+    } else {  // RX: request path
+        if (parse_packet_key(skb, &key, &icmp_type, 0, 1, PATH1_STAGE_2)) {
+            handle_event(ctx, skb, PATH1_STAGE_2, &key, icmp_type);
+        }
+    }
+    return 0;
+}
+"""
+
+# Constants
+MAX_STAGES = 6
+IFNAMSIZ = 16
+TASK_COMM_LEN = 16
+
+class PacketKey(ctypes.Structure):
+    _fields_ = [
+        ("sip", ctypes.c_uint32),
+        ("dip", ctypes.c_uint32),
+        ("proto", ctypes.c_uint8),
+        ("id", ctypes.c_uint16),
+        ("seq", ctypes.c_uint16)
+    ]
+
+class FlowData(ctypes.Structure):
+    _fields_ = [
+        ("ts", ctypes.c_uint64 * MAX_STAGES),
+        ("skb_ptr", ctypes.c_uint64 * MAX_STAGES),
+        ("kstack_id", ctypes.c_int * MAX_STAGES),
+        ("p1_pid", ctypes.c_uint32),
+        ("p1_comm", ctypes.c_char * TASK_COMM_LEN),
+        ("p1_ifname", ctypes.c_char * IFNAMSIZ),
+        ("p2_pid", ctypes.c_uint32),
+        ("p2_comm", ctypes.c_char * TASK_COMM_LEN),
+        ("p2_ifname", ctypes.c_char * IFNAMSIZ),
+        ("request_type", ctypes.c_uint8),
+        ("reply_type", ctypes.c_uint8),
+        ("saw_path1_start", ctypes.c_uint8, 1),
+        ("saw_path1_end", ctypes.c_uint8, 1),
+        ("saw_path2_start", ctypes.c_uint8, 1),
+        ("saw_path2_end", ctypes.c_uint8, 1)
+    ]
+
+class EventData(ctypes.Structure):
+    _fields_ = [
+        ("key", PacketKey),
+        ("data", FlowData)
+    ]
+
+# Debug decoding helpers
+DEBUG_STAGE_NAMES = {
+    0: "P1:S0",
+    1: "P1:S1",
+    2: "P1:S2",
+    3: "P2:S0",
+    4: "P2:S1",
+    5: "P2:S2",
+}
+
+DEBUG_CODE_NAMES = {
+    1: "PROBE_ENTRY",
+    2: "INTERFACE_FILTER",
+    5: "HANDLE_ENTRY",
+    6: "PARSE_ENTRY",
+    7: "PARSE_SUCCESS",
+    8: "IP_FILTER",
+    14: "FLOW_CREATE",
+    15: "FLOW_LOOKUP",
+    16: "FLOW_FOUND",
+    17: "FLOW_NOT_FOUND",
+    19: "PERF_SUBMIT",
+    20: "PARSE_HDR_FAIL",
+    21: "PARSE_NOT_ICMP",
+    22: "PARSE_IP_MISMATCH",
+    23: "PARSE_ICMP_MISMATCH",
+}
+
+# Helper functions
+def get_if_index(devname):
+    """Get the interface index for a device name"""
+    SIOCGIFINDEX = 0x8933
+    if len(devname.encode('ascii')) > 15:
+        raise OSError("Interface name '%s' too long" % devname)
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, 0)
+    buf = struct.pack('16s%dx' % (256-16), devname.encode('ascii'))
+    try:
+        res = fcntl.ioctl(s.fileno(), SIOCGIFINDEX, buf)
+        idx = struct.unpack('I', res[16:20])[0]
+        return idx
+    except IOError as e:
+        raise OSError("ioctl failed for interface '%s': %s" % (devname, e))
+    finally:
+        s.close()
+
+def ip_to_hex(ip_str):
+    """Convert IP string to network-ordered hex value"""
+    if not ip_str or ip_str == "0.0.0.0":
+        return 0
+    try:
+        packed_ip = socket.inet_aton(ip_str)
+        host_int = struct.unpack("!I", packed_ip)[0]
+        return socket.htonl(host_int)
+    except socket.error:
+        print("Error: Invalid IP address format '%s'" % ip_str)
+        sys.exit(1)
+
+def format_ip(addr):
+    """Format integer IP address to string"""
+    return socket.inet_ntop(socket.AF_INET, struct.pack("=I", addr))
+
+def format_latency(ts_start, ts_end):
+    """Format latency value in microseconds"""
+    if ts_start == 0 or ts_end == 0:
+        return " N/A ".rjust(7)
+    delta_ns = ts_end - ts_start
+    delta_us = delta_ns / 1000.0
+    return ("%.3f" % delta_us).rjust(7)
+
+def get_stage_name(stage_id, direction):
+    """Get stage name based on direction"""
+    if direction == "tx":
+        stage_names = {
+            0: "P1:S0 (ip_local_out)",
+            1: "P1:S1 (dev_queue_xmit)",
+            2: "P1:S2 (unused)",
+            3: "P2:S0 (__netif_receive_skb)",
+            4: "P2:S1 (ip_rcv)",
+            5: "P2:S2 (icmp_rcv)"
+        }
+    else:  # rx
+        stage_names = {
+            0: "P1:S0 (__netif_receive_skb)",
+            1: "P1:S1 (ip_rcv)",
+            2: "P1:S2 (icmp_rcv)",
+            3: "P2:S0 (unused)",
+            4: "P2:S1 (ip_local_out)",
+            5: "P2:S2 (dev_queue_xmit)"
+        }
+    return stage_names.get(stage_id, "Unknown")
+
+def print_latency_segment(start_idx, end_idx, flow_data, direction_str):
+    """Print a latency segment"""
+    latency = format_latency(flow_data.ts[start_idx], flow_data.ts[end_idx])
+    start_name = get_stage_name(start_idx, direction_str)
+    end_name = get_stage_name(end_idx, direction_str)
+
+    print("  [%d->%d] %-40s -> %-40s: %s us" % (
+        start_idx, end_idx, start_name, end_name, latency
+    ))
+
+def print_kernel_stack(stage_idx, stack_id, direction):
+    """Print kernel stack trace for a stage"""
+    global args, b
+    stage_name = get_stage_name(stage_idx, direction)
+    print("  Stage %d (%s):" % (stage_idx, stage_name))
+
+    if stack_id <= 0:
+        print("    <No stack trace: id=%d>" % stack_id)
+        return
+
+    try:
+        stack_table = b.get_table("stack_traces")
+        resolved_one = False
+        for addr in stack_table.walk(stack_id):
+            sym = b.ksym(addr, show_offset=True)
+            print("    %s" % sym)
+            resolved_one = True
+
+        if not resolved_one:
+            print("    <No symbols for stack id %d>" % stack_id)
+    except Exception as e:
+        print("    <Error: %s>" % e)
+
+def print_debug_statistics(bpf_obj):
+    """Print debug histogram statistics (bcc-debug-framework)"""
+    try:
+        debug_map = bpf_obj.get_table("debug_stage_stats")
+    except Exception:
+        print("No debug statistics available")
+        return
+
+    entries = []
+    for k, v in debug_map.items():
+        count = v.value if hasattr(v, 'value') else int(v)
+        if count == 0:
+            continue
+        stage_id = k.value >> 8
+        code_point = k.value & 0xFF
+        stage_name = DEBUG_STAGE_NAMES.get(stage_id, "STAGE_%d" % stage_id)
+        code_name = DEBUG_CODE_NAMES.get(code_point, "CODE_%d" % code_point)
+        entries.append((stage_id, code_point, stage_name, code_name, count))
+
+    if not entries:
+        print("No debug counters recorded")
+        return
+
+    print("\n" + "=" * 80)
+    print("Debug Counters (stage_id.code_point -> count)")
+    print("=" * 80)
+    for _, _, stage_name, code_name, count in sorted(entries):
+        print("  %-10s %-15s : %d" % (stage_name, code_name, count))
+
+def print_event(cpu, data, size):
+    global args, b
+    event = ctypes.cast(data, ctypes.POINTER(EventData)).contents
+    key = event.key
+    flow = event.data
+
+    now = datetime.datetime.now()
+    time_str = now.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+
+    trace_dir_str = "TX (Local -> Remote)" if args.direction == "tx" else "RX (Remote -> Local)"
+
+    print("=" * 80)
+    print("=== ICMP RTT Trace: %s (%s) ===" % (time_str, trace_dir_str))
+    print("Session: %s -> %s (ID: %d, Seq: %d)" % (
+        format_ip(key.sip),
+        format_ip(key.dip),
+        socket.ntohs(key.id),
+        socket.ntohs(key.seq)
+    ))
+
+    if args.direction == "tx":
+        path1_desc = "Path 1 (Request: TX to %s)" % args.dst_ip
+        path2_desc = "Path 2 (Reply:   RX from %s)" % args.dst_ip
+    else:
+        path1_desc = "Path 1 (Request: RX from %s)" % args.dst_ip
+        path2_desc = "Path 2 (Reply:   TX to %s)" % args.dst_ip
+
+    print("%-45s: PID=%-6d COMM=%-12s IF=%-10s ICMP_Type=%d" % (
+        path1_desc,
+        flow.p1_pid,
+        flow.p1_comm.decode('utf-8', 'replace'),
+        flow.p1_ifname.decode('utf-8', 'replace'),
+        flow.request_type
+    ))
+
+    print("%-45s: PID=%-6d COMM=%-12s IF=%-10s ICMP_Type=%d" % (
+        path2_desc,
+        flow.p2_pid,
+        flow.p2_comm.decode('utf-8', 'replace'),
+        flow.p2_ifname.decode('utf-8', 'replace'),
+        flow.reply_type
+    ))
+
+    print("\nSKB Pointers:")
+    for i in range(MAX_STAGES):
+        if flow.skb_ptr[i] != 0:
+            stage_name = get_stage_name(i, args.direction)
+            print("  Stage %d (%-40s): 0x%x" % (i, stage_name, flow.skb_ptr[i]))
+
+    print("\nPath 1 Latencies (us):")
+    print_latency_segment(0, 1, flow, args.direction)
+    if args.direction == "rx":
+        print_latency_segment(1, 2, flow, args.direction)
+        if flow.ts[0] > 0 and flow.ts[2] > 0:
+            path1_total = format_latency(flow.ts[0], flow.ts[2])
+            print("  Total Path 1: %s us" % path1_total)
+    else:
+        if flow.ts[0] > 0 and flow.ts[1] > 0:
+            path1_total = format_latency(flow.ts[0], flow.ts[1])
+            print("  Total Path 1: %s us" % path1_total)
+
+    print("\nPath 2 Latencies (us):")
+    if args.direction == "tx":
+        print_latency_segment(3, 4, flow, args.direction)
+        print_latency_segment(4, 5, flow, args.direction)
+        if flow.ts[3] > 0 and flow.ts[5] > 0:
+            path2_total = format_latency(flow.ts[3], flow.ts[5])
+            print("  Total Path 2: %s us" % path2_total)
+    else:
+        print_latency_segment(4, 5, flow, args.direction)
+        if flow.ts[4] > 0 and flow.ts[5] > 0:
+            path2_total = format_latency(flow.ts[4], flow.ts[5])
+            print("  Total Path 2: %s us" % path2_total)
+
+    if flow.ts[0] > 0 and flow.ts[5] > 0:
+        rtt = format_latency(flow.ts[0], flow.ts[5])
+        print("\nTotal RTT (Path1 Start to Path2 End): %s us" % rtt)
+
+        if args.direction == "tx" and flow.ts[1] > 0 and flow.ts[3] > 0:
+            inter_path_latency = format_latency(flow.ts[1], flow.ts[3])
+            print("Inter-Path Latency (P1 end -> P2 start): %s us" % inter_path_latency)
+        if args.direction == "rx" and flow.ts[2] > 0 and flow.ts[4] > 0:
+            inter_path_latency = format_latency(flow.ts[2], flow.ts[4])
+            print("Inter-Path Latency (P1 end -> P2 start): %s us" % inter_path_latency)
+
+    if not args.disable_kernel_stacks:
+        print("\nKernel Stack Traces:")
+        for i in range(MAX_STAGES):
+            if flow.ts[i] != 0:
+                print_kernel_stack(i, flow.kstack_id[i], args.direction)
+
+    print("=" * 80 + "\n")
+
+if __name__ == "__main__":
+    if os.geteuid() != 0:
+        print("This program must be run as root")
+        sys.exit(1)
+
+    parser = argparse.ArgumentParser(
+        description="Trace ICMP RTT through kernel network stack (no OVS)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  TX mode (local ping remote):
+    sudo ./kernel_icmp_rtt.py --src-ip 192.168.1.10 --dst-ip 192.168.1.20 \\
+                              --interface eth0 --direction tx
+
+  RX mode (remote ping local):
+    sudo ./kernel_icmp_rtt.py --src-ip 192.168.1.10 --dst-ip 192.168.1.20 \\
+                              --interface eth0 --direction rx
+
+  With latency threshold:
+    sudo ./kernel_icmp_rtt.py --src-ip 192.168.1.10 --dst-ip 192.168.1.20 \\
+                              --interface eth0 --latency-ms 10
+"""
+    )
+
+    parser.add_argument('--src-ip', type=str, required=True,
+                      help='Local IP address (source for TX, destination for RX)')
+    parser.add_argument('--dst-ip', type=str, required=True,
+                      help='Remote IP address (destination for TX, source for RX)')
+    parser.add_argument('--interface', type=str, required=False, default=None,
+                      help='Network interface to monitor (optional, monitors all if not specified)')
+    parser.add_argument('--latency-ms', type=float, default=0,
+                      help='Minimum RTT latency threshold in ms (default: 0, report all)')
+    parser.add_argument('--direction', type=str, choices=["tx", "rx"], default="tx",
+                      help='Direction: "tx" (local pings remote) or "rx" (remote pings local)')
+    parser.add_argument('--disable-kernel-stacks', action='store_true', default=False,
+                      help='Disable kernel stack trace output')
+    parser.add_argument('--debug', action='store_true', default=False,
+                      help='Enable verbose BPF debug trace output (trace_pipe)')
+
+    args = parser.parse_args()
+
+    direction_val = 0 if args.direction == "tx" else 1
+    debug_enable_val = 1 if args.debug else 0
+
+    ifindex = 0
+    if args.interface:
+        try:
+            ifindex = get_if_index(args.interface)
+        except OSError as e:
+            print("Error getting interface index: %s" % e)
+            sys.exit(1)
+
+    src_ip_hex_val = ip_to_hex(args.src_ip)
+    dst_ip_hex_val = ip_to_hex(args.dst_ip)
+    latency_threshold_ns_val = int(args.latency_ms * 1000000)
+
+    print("=== Kernel ICMP RTT Tracer ===")
+    print("Trace Direction: %s" % args.direction.upper())
+    print("SRC_IP_FILTER (Local IP): %s (0x%x)" % (args.src_ip, socket.ntohl(src_ip_hex_val)))
+    print("DST_IP_FILTER (Remote IP): %s (0x%x)" % (args.dst_ip, socket.ntohl(dst_ip_hex_val)))
+
+    if args.interface:
+        print("Monitoring interface: %s (ifindex %d)" % (args.interface, ifindex))
+    else:
+        print("Monitoring all interfaces")
+
+    if latency_threshold_ns_val > 0:
+        print("Reporting only RTT >= %.3f ms" % args.latency_ms)
+
+    if args.debug:
+        print("Debug counters enabled (bcc-debug-framework); will print on exit")
+
+    try:
+        b = BPF(text=bpf_text % (
+            debug_enable_val,
+            src_ip_hex_val,
+            dst_ip_hex_val,
+            latency_threshold_ns_val,
+            ifindex,
+            direction_val
+        ))
+        print("\nBPF program loaded successfully")
+    except Exception as e:
+        print("Error loading BPF program: %s" % e)
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+    # Verify probe attachment
+    print("\nVerifying probe attachments:")
+    probe_functions = [
+        "ip_local_out",
+        "dev_queue_xmit",
+        "ip_rcv",
+        "icmp_rcv"
+    ]
+
+    for func in probe_functions:
+        # Try to check if function exists in kernel
+        try:
+            with open("/proc/kallsyms", "r") as f:
+                if any(func in line for line in f):
+                    print("  [OK] %s found in kallsyms" % func)
+                else:
+                    print("  [WARN] %s NOT found in kallsyms - probe may fail!" % func)
+        except:
+            pass
+
+    # Check tracepoint
+    import glob
+    tp_path = "/sys/kernel/debug/tracing/events/net/netif_receive_skb"
+    if os.path.exists(tp_path):
+        print("  [OK] netif_receive_skb tracepoint exists")
+    else:
+        print("  [WARN] netif_receive_skb tracepoint NOT found!")
+        # Try alternative
+        tp_alt = "/sys/kernel/debug/tracing/events/net/netif_rx"
+        if os.path.exists(tp_alt):
+            print("  [INFO] Found alternative: netif_rx tracepoint")
+
+    b["events"].open_perf_buffer(print_event)
+
+    print("\nTracing ICMP RTT (src=%s, dst=%s, dir=%s) ... Hit Ctrl-C to end." %
+          (args.src_ip, args.dst_ip, args.direction))
+
+    try:
+        while True:
+            b.perf_buffer_poll()
+    except KeyboardInterrupt:
+        print("\nDetaching...")
+    finally:
+        if args.debug:
+            print_debug_statistics(b)
+        print("Exiting.")

--- a/measurement-tools/performance/system-network/system_network_icmp_rtt.py
+++ b/measurement-tools/performance/system-network/system_network_icmp_rtt.py
@@ -96,7 +96,6 @@ import fcntl # Needed for ioctl
 # --- BPF Program ---
 bpf_text = """
 #include <uapi/linux/ptrace.h>
-#include <net/sock.h>
 #include <bcc/proto.h>
 #include <linux/skbuff.h>
 #include <linux/icmp.h>
@@ -105,7 +104,6 @@ bpf_text = """
 #include <linux/if_vlan.h>
 #include <linux/sched.h>
 #include <linux/netdevice.h>
-#include <net/flow.h>
 
 // User-defined filters
 #define SRC_IP_FILTER 0x%x
@@ -318,14 +316,14 @@ static __always_inline int parse_packet_key(struct sk_buff *skb, struct packet_k
     if (stage_id == PATH1_STAGE_4 || stage_id == PATH2_STAGE_4) {
          return parse_packet_key_userspace(skb, key, icmp_type_out, path_is_primary);
     }
-    
+
     if (skb == NULL) {
         return 0;
     }
 
     unsigned char *head;
-    u16 network_header_offset; 
-    u16 transport_header_offset; 
+    u16 network_header_offset;
+    u16 transport_header_offset;
 
     if (bpf_probe_read_kernel(&head, sizeof(head), &skb->head) < 0 ||
         bpf_probe_read_kernel(&network_header_offset, sizeof(network_header_offset), &skb->network_header) < 0 ||
@@ -333,8 +331,8 @@ static __always_inline int parse_packet_key(struct sk_buff *skb, struct packet_k
         return 0;
     }
 
-    if (network_header_offset == (u16)~0U || network_header_offset > 2048 ) { 
-        return 0; 
+    if (network_header_offset == (u16)~0U || network_header_offset > 2048 ) {
+        return 0;
     }
 
     struct iphdr ip;
@@ -350,29 +348,27 @@ static __always_inline int parse_packet_key(struct sk_buff *skb, struct packet_k
         return 0;
     }
 
-    if (path_is_primary) { 
+    if (path_is_primary) {
         if (!(actual_sip == SRC_IP_FILTER && actual_dip == DST_IP_FILTER)) {
-        return 0;
-    }
+            return 0;
+        }
         expected_icmp_type_val = ICMP_ECHO;
-    } else { 
+    } else {
         if (!(actual_sip == DST_IP_FILTER && actual_dip == SRC_IP_FILTER)) {
-        return 0;
-    }
+            return 0;
+        }
         expected_icmp_type_val = ICMP_ECHOREPLY;
     }
 
-    u8 ip_ihl = ip.ihl & 0x0F;  
-    if (ip_ihl < 5) {  
+    u8 ip_ihl = ip.ihl & 0x0F;
+    if (ip_ihl < 5) {
         return 0;
     }
 
-    //bpf_trace_printk("ParsePktKey: Stg=%%d, actual_sip=%%x, actual_dip=%%x", stage_id, actual_sip, actual_dip);
-    //bpf_trace_printk("ParsePktKey: Stg=%%d, net_hdr_off=%%d, trans_hdr_off=%%d", stage_id, network_header_offset, transport_header_offset);
     if (transport_header_offset == 0 || transport_header_offset == (u16)~0U || transport_header_offset == network_header_offset) {
         transport_header_offset = network_header_offset + (ip_ihl * 4);
     }
-    
+
     struct icmphdr icmph;
     if (bpf_probe_read_kernel(&icmph, sizeof(icmph), head + transport_header_offset) < 0) {
         return 0;
@@ -381,72 +377,55 @@ static __always_inline int parse_packet_key(struct sk_buff *skb, struct packet_k
     if (icmph.type != expected_icmp_type_val) {
         return 0;
     }
-    //bpf_trace_printk("ParsePktKey: Stg=%%d, icmp_type=%%d", stage_id, icmph.type);
-    //bpf_trace_printk("ParsePktKey: Stg=%%d, icmp_seq=%%d, icmp_id=%%d", stage_id, icmph.un.echo.sequence, icmph.un.echo.id);
 
     *icmp_type_out = icmph.type;
-    key->sip = SRC_IP_FILTER; 
+    key->sip = SRC_IP_FILTER;
     key->dip = DST_IP_FILTER;
-    key->proto = ip.protocol; 
+    key->proto = ip.protocol;
     key->id = icmph.un.echo.id;
     key->seq = icmph.un.echo.sequence;
 
     return 1;
 }
 
-static __always_inline void handle_event(struct pt_regs *ctx, struct sk_buff *skb, 
+static __always_inline void handle_event(struct pt_regs *ctx, struct sk_buff *skb,
                                          u64 current_stage_global_id, struct packet_key_t *parsed_packet_key, u8 actual_icmp_type) {
     if (skb == NULL) {
-        //bpf_trace_printk("HdlEvt: SKB NULL. Stg=%%d", current_stage_global_id);
         return;
     }
 
-    if (TRACE_DIRECTION == 0 && current_stage_global_id == PATH2_STAGE_0) { 
+    if (TRACE_DIRECTION == 0 && current_stage_global_id == PATH2_STAGE_0) {
         if (!is_target_ifindex(skb)){
-            //bpf_trace_printk("HdlEvt: Out P2S0 !target_if. Stg=%%d", current_stage_global_id);
             return;
         }
     }
-    if (TRACE_DIRECTION == 1 && current_stage_global_id == PATH1_STAGE_0) { 
+    if (TRACE_DIRECTION == 1 && current_stage_global_id == PATH1_STAGE_0) {
          if (!is_target_ifindex(skb)){
-            //bpf_trace_printk("HdlEvt: In P1S0 !target_if. Stg=%%d", current_stage_global_id);
             return;
         }
     }
-    
+
     u64 current_ts = bpf_ktime_get_ns();
-    int stack_id = stack_traces.get_stackid(ctx, BPF_F_REUSE_STACKID); // Attempt kernel stacks only
-    
+    int stack_id = stack_traces.get_stackid(ctx, BPF_F_REUSE_STACKID);
+
     struct flow_data_t *flow_ptr;
 
     if (current_stage_global_id == PATH1_STAGE_0) {
         struct flow_data_t zero = {};
         flow_sessions.delete(parsed_packet_key);
         flow_ptr = flow_sessions.lookup_or_try_init(parsed_packet_key, &zero);
-        if (flow_ptr) {
-            //bpf_trace_printk("HdlEvt: Flow init/lookup OK. Stg=%%d", current_stage_global_id);
-        } else {
-            //bpf_trace_printk("HdlEvt: Flow init/lookup FAILED. Stg=%%d", current_stage_global_id);
-        }
     } else {
         flow_ptr = flow_sessions.lookup(parsed_packet_key);
-        if (flow_ptr) {
-            //bpf_trace_printk("HdlEvt: Flow lookup OK. Stg=%%d", current_stage_global_id);
-        } else {
-            //bpf_trace_printk("HdlEvt: Flow lookup FAILED. Stg=%%d", current_stage_global_id);
-        }
     }
 
     if (!flow_ptr) {
-        //bpf_trace_printk("HdlEvt: flow_ptr NULL after lookup. Stg=%%d", current_stage_global_id);
-        return; 
+        return;
     }
 
-    if (flow_ptr->ts[current_stage_global_id] == 0) { 
+    if (flow_ptr->ts[current_stage_global_id] == 0) {
         flow_ptr->ts[current_stage_global_id] = current_ts;
         flow_ptr->skb_ptr[current_stage_global_id] = (u64)skb;
         flow_ptr->kstack_id[current_stage_global_id] = stack_id;
-        //bpf_trace_printk("HdlEvt: Updating TS for Stg=%%d, stack_id=%%d", current_stage_global_id, stack_id);
 
         struct net_device *dev;
         char if_name_buffer[IFNAMSIZ];
@@ -502,28 +481,26 @@ static __always_inline void handle_event(struct pt_regs *ctx, struct sk_buff *sk
             }
         }
         
-        //bpf_trace_printk("HdlEvt: PerfSubmit. Stg=%%d RTT=%%lld", current_stage_global_id, (rtt_end_ts - rtt_start_ts));
-        
-        u32 map_key_zero = 0; 
+        u32 map_key_zero = 0;
         struct event_data_t *event_data_ptr = event_scratch_map.lookup(&map_key_zero);
         if (!event_data_ptr) {
-            return; 
-        }
-        
-        event_data_ptr->key = *parsed_packet_key; 
-        
-        if (bpf_probe_read_kernel(&event_data_ptr->data, sizeof(event_data_ptr->data), flow_ptr) != 0) {
-            flow_sessions.delete(parsed_packet_key); 
             return;
         }
-        
+
+        event_data_ptr->key = *parsed_packet_key;
+
+        if (bpf_probe_read_kernel(&event_data_ptr->data, sizeof(event_data_ptr->data), flow_ptr) != 0) {
+            flow_sessions.delete(parsed_packet_key);
+            return;
+        }
+
         events.perf_submit(ctx, event_data_ptr, sizeof(*event_data_ptr));
-        
-        flow_sessions.delete(parsed_packet_key); 
+
+        flow_sessions.delete(parsed_packet_key);
     }
 }
 
-int kprobe__ip_send_skb(struct pt_regs *ctx, struct net *net, struct sk_buff *skb) {
+int kprobe__ip_output(struct pt_regs *ctx, struct net *net, struct sock *sk, struct sk_buff *skb) {
     struct packet_key_t key = {};
     u8 icmp_type = 0;
 
@@ -542,12 +519,12 @@ int kprobe__ip_send_skb(struct pt_regs *ctx, struct net *net, struct sk_buff *sk
 int kprobe__internal_dev_xmit(struct pt_regs *ctx, struct sk_buff *skb) {
     struct packet_key_t key = {};
     u8 icmp_type = 0;
-    
-    if (TRACE_DIRECTION == 0) { 
+
+    if (TRACE_DIRECTION == 0) {
         if (parse_packet_key(skb, &key, &icmp_type, 1, PATH1_STAGE_1)) {
             handle_event(ctx, skb, PATH1_STAGE_1, &key, icmp_type);
         }
-    } else { 
+    } else {
         if (parse_packet_key(skb, &key, &icmp_type, 0, PATH2_STAGE_1)) {
             handle_event(ctx, skb, PATH2_STAGE_1, &key, icmp_type);
         }
@@ -555,8 +532,8 @@ int kprobe__internal_dev_xmit(struct pt_regs *ctx, struct sk_buff *skb) {
     return 0;
 }
 
-RAW_TRACEPOINT_PROBE(netif_receive_skb) {
-    struct sk_buff *skb = (struct sk_buff *)ctx->args[0];
+TRACEPOINT_PROBE(net, netif_receive_skb) {
+    struct sk_buff *skb = (struct sk_buff *)args->skbaddr;
     if (!skb) return 0;
 
     struct packet_key_t key = {};
@@ -564,30 +541,30 @@ RAW_TRACEPOINT_PROBE(netif_receive_skb) {
 
     if (TRACE_DIRECTION == 0) {
         if (parse_packet_key(skb, &key, &icmp_type, 0, PATH2_STAGE_0)) {
-            handle_event(ctx, skb, PATH2_STAGE_0, &key, icmp_type);
+            handle_event(args, skb, PATH2_STAGE_0, &key, icmp_type);
         }
     } else {
         if (parse_packet_key(skb, &key, &icmp_type, 1, PATH1_STAGE_0)) {
-            handle_event(ctx, skb, PATH1_STAGE_0, &key, icmp_type);
+            handle_event(args, skb, PATH1_STAGE_0, &key, icmp_type);
         }
     }
     return 0;
 }
 
 int kprobe__netdev_frame_hook(struct pt_regs *ctx, struct sk_buff **pskb) {
-    struct sk_buff *skb = NULL; 
+    struct sk_buff *skb = NULL;
     if (bpf_probe_read_kernel(&skb, sizeof(skb), pskb) < 0 || skb == NULL) {
         return 0;
     }
-    
-    struct packet_key_t key_parsed = {}; 
-    u8 icmp_type_parsed = 0; 
-    
-    if (TRACE_DIRECTION == 0) { 
+
+    struct packet_key_t key_parsed = {};
+    u8 icmp_type_parsed = 0;
+
+    if (TRACE_DIRECTION == 0) {
         if (parse_packet_key(skb, &key_parsed, &icmp_type_parsed, 0, PATH2_STAGE_1)) {
             handle_event(ctx, skb, PATH2_STAGE_1, &key_parsed, icmp_type_parsed);
         }
-    } else { 
+    } else {
         if (parse_packet_key(skb, &key_parsed, &icmp_type_parsed, 1, PATH1_STAGE_1)) {
             handle_event(ctx, skb, PATH1_STAGE_1, &key_parsed, icmp_type_parsed);
         }
@@ -597,14 +574,14 @@ int kprobe__netdev_frame_hook(struct pt_regs *ctx, struct sk_buff **pskb) {
 
 int kprobe__ovs_dp_process_packet(struct pt_regs *ctx, const struct sk_buff *skb_const) {
     struct sk_buff *skb = (struct sk_buff *)skb_const;
-    struct packet_key_t key = {}; 
+    struct packet_key_t key = {};
     u8 icmp_type = 0;
 
-    if (parse_packet_key(skb, &key, &icmp_type, 1, PATH1_STAGE_2)) { 
+    if (parse_packet_key(skb, &key, &icmp_type, 1, PATH1_STAGE_2)) {
         handle_event(ctx, skb, PATH1_STAGE_2, &key, icmp_type);
     }
-    key = (struct packet_key_t){}; icmp_type = 0; 
-    if (parse_packet_key(skb, &key, &icmp_type, 0, PATH2_STAGE_2)) { 
+    key = (struct packet_key_t){}; icmp_type = 0;
+    if (parse_packet_key(skb, &key, &icmp_type, 0, PATH2_STAGE_2)) {
         handle_event(ctx, skb, PATH2_STAGE_2, &key, icmp_type);
     }
 
@@ -619,7 +596,7 @@ int kprobe__ovs_dp_upcall(struct pt_regs *ctx, void *dp, const struct sk_buff *s
     if (parse_packet_key(skb, &key, &icmp_type, 1, PATH1_STAGE_3)) {
         handle_event(ctx, skb, PATH1_STAGE_3, &key, icmp_type);
     }
-    
+
     key = (struct packet_key_t){}; icmp_type = 0;
     if (parse_packet_key(skb, &key, &icmp_type, 0, PATH2_STAGE_3)) {
         handle_event(ctx, skb, PATH2_STAGE_3, &key, icmp_type);
@@ -634,12 +611,12 @@ int kprobe__ovs_flow_key_extract_userspace(struct pt_regs *ctx, struct net *net,
     struct packet_key_t key = {};
     u8 icmp_type = 0;
 
-    if (parse_packet_key(skb, &key, &icmp_type, 1, PATH1_STAGE_4)) { 
+    if (parse_packet_key(skb, &key, &icmp_type, 1, PATH1_STAGE_4)) {
         handle_event(ctx, skb, PATH1_STAGE_4, &key, icmp_type);
     }
 
     key = (struct packet_key_t){}; icmp_type = 0;
-    if (parse_packet_key(skb, &key, &icmp_type, 0, PATH2_STAGE_4)) { 
+    if (parse_packet_key(skb, &key, &icmp_type, 0, PATH2_STAGE_4)) {
         handle_event(ctx, skb, PATH2_STAGE_4, &key, icmp_type);
     }
     return 0;
@@ -664,15 +641,15 @@ int kprobe__dev_queue_xmit(struct pt_regs *ctx, struct sk_buff *skb) {
     if (!is_target_ifindex(skb)) {
         return 0;
     }
-        
+
     struct packet_key_t key = {};
     u8 icmp_type = 0;
-    
-    if (TRACE_DIRECTION == 0) { 
+
+    if (TRACE_DIRECTION == 0) {
         if (parse_packet_key(skb, &key, &icmp_type, 1, PATH1_STAGE_6)) {
             handle_event(ctx, skb, PATH1_STAGE_6, &key, icmp_type);
         }
-    } else { 
+    } else {
         if (parse_packet_key(skb, &key, &icmp_type, 0, PATH2_STAGE_6)) {
             handle_event(ctx, skb, PATH2_STAGE_6, &key, icmp_type);
         }
@@ -683,12 +660,12 @@ int kprobe__dev_queue_xmit(struct pt_regs *ctx, struct sk_buff *skb) {
 int kprobe__icmp_rcv(struct pt_regs *ctx, struct sk_buff *skb) {
     struct packet_key_t key = {};
     u8 icmp_type = 0;
-    
-    if (TRACE_DIRECTION == 0) { 
+
+    if (TRACE_DIRECTION == 0) {
         if (parse_packet_key(skb, &key, &icmp_type, 0, PATH2_STAGE_6)) {
             handle_event(ctx, skb, PATH2_STAGE_6, &key, icmp_type);
         }
-    } else { 
+    } else {
         if (parse_packet_key(skb, &key, &icmp_type, 1, PATH1_STAGE_6)) {
             handle_event(ctx, skb, PATH1_STAGE_6, &key, icmp_type);
         }
@@ -794,7 +771,7 @@ def get_detailed_stage_name(stage_id, direction):
     }
     
     probe_map_tx = {
-        0: "ip_send_skb",       1: "internal_dev_xmit",  2: "ovs_dp_process_packet",
+        0: "ip_output",       1: "internal_dev_xmit",  2: "ovs_dp_process_packet",
         3: "ovs_dp_upcall",     4: "ovs_flow_key_extract_userspace", 5: "ovs_vport_send",
         6: "dev_queue_xmit",
         7: "__netif_receive_skb", 8: "netdev_frame_hook",  9: "ovs_dp_process_packet",
@@ -806,7 +783,7 @@ def get_detailed_stage_name(stage_id, direction):
         0: "__netif_receive_skb", 1: "netdev_frame_hook",  2: "ovs_dp_process_packet",
         3: "ovs_dp_upcall",     4: "ovs_flow_key_extract_userspace", 5: "ovs_vport_send",
         6: "icmp_rcv",
-        7: "ip_send_skb",       8: "internal_dev_xmit",  9: "ovs_dp_process_packet",
+        7: "ip_output",       8: "internal_dev_xmit",  9: "ovs_dp_process_packet",
         10: "ovs_dp_upcall",    11: "ovs_flow_key_extract_userspace",12: "ovs_vport_send",
         13: "dev_queue_xmit"
     }
@@ -1013,6 +990,7 @@ def print_event(cpu, data, size):
     
     print("\n" + "="*50 + "\n")
 
+
 if __name__ == "__main__":
     if os.geteuid() != 0:
         print("This program must be run as root")
@@ -1097,7 +1075,7 @@ Examples:
         sys.exit(1)
         
     probe_functions = [
-        ("ip_send_skb", "kprobe__ip_send_skb"),
+        ("ip_output", "kprobe__ip_output"),
         ("internal_dev_xmit", "kprobe__internal_dev_xmit"),
         ("netdev_frame_hook", "kprobe__netdev_frame_hook"),
         ("ovs_dp_process_packet", "kprobe__ovs_dp_process_packet"),
@@ -1114,8 +1092,7 @@ Examples:
     
     try:
         while True:
-            b.perf_buffer_poll() 
+            b.perf_buffer_poll()
     except KeyboardInterrupt:
         print("\nDetaching...")
-    finally:
         print("Exiting.") 

--- a/measurement-tools/performance/system-network/system_network_latency_summary.py
+++ b/measurement-tools/performance/system-network/system_network_latency_summary.py
@@ -1,0 +1,1146 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+System Network Adjacent Stage Latency Histogram Tool
+
+Measures latency distribution between adjacent network stack stages using BPF_HISTOGRAM.
+Only tracks latencies between consecutive processing stages in the actual packet path.
+
+Based on:
+- system_network_latency_details.py: Stage definitions and probe points
+- vm_network_latency_summary.py: Histogram aggregation architecture
+
+Usage:
+    sudo ./system_network_latency_summary.py --phy-interface enp94s0f0np0 \
+                                --src-ip 70.0.0.33 --direction tx --interval 5
+
+"""
+
+# BCC module import with fallback
+try:
+    from bcc import BPF
+except ImportError:
+    try:
+        from bpfcc import BPF
+    except ImportError:
+        import sys
+        print("Error: Neither bcc nor bpfcc module found!")
+        if sys.version_info[0] == 3:
+            print("Please install: python3-bcc or python3-bpfcc")
+        else:
+            print("Please install: python-bcc or python2-bcc")
+        sys.exit(1)
+
+from time import sleep, strftime, time as time_time
+import argparse
+import ctypes
+import socket
+import struct
+import os
+import sys
+import datetime
+import fcntl
+import signal
+
+# Global configuration
+direction_filter = 1  # 1=tx (System->Physical), 2=rx (Physical->System)
+
+# BPF Program
+bpf_text = """
+#include <uapi/linux/ptrace.h>
+#include <net/sock.h>
+#include <bcc/proto.h>
+#include <linux/skbuff.h>
+#include <linux/tcp.h>
+#include <linux/udp.h>
+#include <linux/ip.h>
+#include <linux/if_ether.h>
+#include <linux/if_vlan.h>
+#include <linux/sched.h>
+#include <linux/netdevice.h>
+#include <net/flow.h>
+#include <net/inet_sock.h>
+#include <net/tcp.h>
+
+struct net;
+struct inet_cork;
+
+// User-defined filters
+#define SRC_IP_FILTER 0x%x
+#define DST_IP_FILTER 0x%x
+#define SRC_PORT_FILTER %d
+#define DST_PORT_FILTER %d
+#define PROTOCOL_FILTER %d  // 0=all, 6=TCP, 17=UDP
+#define TARGET_IFINDEX1 %d
+#define TARGET_IFINDEX2 %d
+#define DIRECTION_FILTER %d  // 1=tx, 2=rx
+
+// Stage definitions - from system_network_latency_details.py
+// TX direction stages (System -> Physical)
+#define TX_STAGE_0    0  // ip_queue_xmit (TCP) / ip_send_skb (UDP)
+#define TX_STAGE_1    1  // internal_dev_xmit
+#define TX_STAGE_2    2  // ovs_dp_process_packet
+#define TX_STAGE_3    3  // ovs_dp_upcall
+#define TX_STAGE_4    4  // ovs_flow_key_extract_userspace
+#define TX_STAGE_5    5  // ovs_vport_send
+#define TX_STAGE_6    6  // dev_queue_xmit (physical)
+
+// RX direction stages (Physical -> System)
+#define RX_STAGE_0    7  // __netif_receive_skb (physical)
+#define RX_STAGE_1    8  // netdev_frame_hook
+#define RX_STAGE_2    9  // ovs_dp_process_packet
+#define RX_STAGE_3    10 // ovs_dp_upcall
+#define RX_STAGE_4    11 // ovs_flow_key_extract_userspace
+#define RX_STAGE_5    12 // ovs_vport_send
+#define RX_STAGE_6    13 // tcp_v4_rcv/udp_rcv (protocol specific)
+
+#define MAX_STAGES               14
+#define IFNAMSIZ                 16
+
+// Packet key structure - same as system_network_latency_details.py
+struct packet_key_t {
+    __be32 src_ip;
+    __be32 dst_ip;
+    u8 protocol;
+    u8 pad[3];
+
+    union {
+        struct {
+            __be16 src_port;
+            __be16 dst_port;
+            __be32 seq;          // TCP sequence number
+        } tcp;
+
+        struct {
+            __be16 src_port;
+            __be16 dst_port;
+            __be16 ip_id;        // IP identification
+            __be16 udp_len;
+            __be16 frag_off;     // Fragment offset
+        } udp;
+    };
+};
+
+// Flow tracking - minimal for summary mode
+struct flow_data_t {
+    u64 first_timestamp;               // Timestamp of first stage (for total latency)
+    u64 last_timestamp;                // Timestamp of last stage
+    u8 direction;                      // 1=tx, 2=rx
+    u8 last_stage;                     // Last valid stage seen
+    u8 pad[4];                         // Padding for alignment
+};
+
+// Stage pair key for histogram with latency bucket
+struct stage_pair_key_t {
+    u8 prev_stage;
+    u8 curr_stage;
+    u8 direction;
+    u8 latency_bucket;  // log2 of latency in microseconds
+};
+
+// Maps
+BPF_TABLE("lru_hash", struct packet_key_t, struct flow_data_t, flow_sessions, 10240);
+
+// BPF Histogram for adjacent stage latencies
+BPF_HISTOGRAM(adjacent_latency_hist, struct stage_pair_key_t, 1024);
+
+// BPF Histogram for total end-to-end latency
+BPF_HISTOGRAM(total_latency_hist, u8, 256);
+
+// Performance statistics
+BPF_ARRAY(packet_counters, u64, 4);  // 0=total, 1=tx, 2=rx, 3=dropped
+BPF_ARRAY(flow_stage_counters, u64, 4);  // 0=first_stage_tx, 1=last_stage_tx, 2=first_stage_rx, 3=last_stage_rx
+
+// Helper function to check if an interface index matches our targets
+static __always_inline bool is_target_ifindex(const struct sk_buff *skb) {
+    struct net_device *dev = NULL;
+    int ifindex = 0;
+
+    if (bpf_probe_read_kernel(&dev, sizeof(dev), &skb->dev) < 0 || dev == NULL) {
+        return false;
+    }
+
+    if (bpf_probe_read_kernel(&ifindex, sizeof(ifindex), &dev->ifindex) < 0) {
+        return false;
+    }
+
+    return (ifindex == TARGET_IFINDEX1 || ifindex == TARGET_IFINDEX2);
+}
+
+// Helper functions for packet parsing - from system_network_latency_details.py
+static __always_inline int get_ip_header(struct sk_buff *skb, struct iphdr *ip, u8 stage_id) {
+    unsigned char *head;
+    u16 network_header_offset;
+
+    if (bpf_probe_read_kernel(&head, sizeof(head), &skb->head) < 0 ||
+        bpf_probe_read_kernel(&network_header_offset, sizeof(network_header_offset), &skb->network_header) < 0) {
+        return -1;
+    }
+
+    if (network_header_offset == (u16)~0U || network_header_offset > 2048) {
+        return -1;
+    }
+
+    if (bpf_probe_read_kernel(ip, sizeof(*ip), head + network_header_offset) < 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static __always_inline int get_transport_header(struct sk_buff *skb, void *hdr, u16 hdr_size, u8 stage_id) {
+    unsigned char *head;
+    u16 transport_header_offset;
+    u16 network_header_offset;
+
+    if (bpf_probe_read_kernel(&head, sizeof(head), &skb->head) < 0 ||
+        bpf_probe_read_kernel(&transport_header_offset, sizeof(transport_header_offset), &skb->transport_header) < 0 ||
+        bpf_probe_read_kernel(&network_header_offset, sizeof(network_header_offset), &skb->network_header) < 0) {
+        return -1;
+    }
+
+    if (transport_header_offset == 0 || transport_header_offset == (u16)~0U || transport_header_offset == network_header_offset) {
+        // Calculate transport header offset from IP header
+        struct iphdr ip;
+        if (bpf_probe_read_kernel(&ip, sizeof(ip), head + network_header_offset) < 0) {
+            return -1;
+        }
+        u8 ip_ihl = ip.ihl & 0x0F;
+        if (ip_ihl < 5) return -1;
+        transport_header_offset = network_header_offset + (ip_ihl * 4);
+    }
+
+    if (bpf_probe_read_kernel(hdr, hdr_size, head + transport_header_offset) < 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+// TCP protocol parsing
+static __always_inline int parse_tcp_key(
+    struct sk_buff *skb,
+    struct packet_key_t *key,
+    u8 stage_id
+) {
+    struct tcphdr tcp;
+    if (get_transport_header(skb, &tcp, sizeof(tcp), stage_id) != 0) return 0;
+
+    key->tcp.src_port = tcp.source;
+    key->tcp.dst_port = tcp.dest;
+    key->tcp.seq = tcp.seq;
+
+    return 1;
+}
+
+// UDP protocol parsing
+static __always_inline int parse_udp_key(
+    struct sk_buff *skb,
+    struct packet_key_t *key,
+    u8 stage_id
+) {
+    struct iphdr ip;
+    if (get_ip_header(skb, &ip, stage_id) != 0) return 0;
+
+    key->udp.ip_id = ip.id;
+
+    // Get fragmentation information
+    struct udphdr udp = {};
+    if (get_transport_header(skb, &udp, sizeof(udp), stage_id) == 0) {
+        key->udp.src_port = udp.source;
+        key->udp.dst_port = udp.dest;
+        key->udp.udp_len = udp.len;
+    } else {
+        key->udp.src_port = 0;
+        key->udp.dst_port = 0;
+        key->udp.udp_len = 0;
+    }
+
+    return 1;
+}
+
+// Specialized parsing function for userspace SKB
+static __always_inline int parse_packet_key_userspace(
+    struct sk_buff *skb,
+    struct packet_key_t *key,
+    u8 stage_id,
+    u8 direction
+) {
+    if (skb == NULL) {
+        return 0;
+    }
+
+    unsigned char *skb_head;
+    if(bpf_probe_read_kernel(&skb_head, sizeof(skb_head), &skb->head) < 0) {
+        return 0;
+    }
+    if (!skb_head) {
+        return 0;
+    }
+
+    unsigned long skb_data_ptr_val;
+    if(bpf_probe_read_kernel(&skb_data_ptr_val, sizeof(skb_data_ptr_val), &skb->data) < 0) {
+        return 0;
+    }
+
+    unsigned int data_offset = (unsigned int)(skb_data_ptr_val - (unsigned long)skb_head);
+    unsigned int mac_offset = data_offset;
+
+    struct ethhdr eth;
+    if (bpf_probe_read_kernel(&eth, sizeof(eth), skb_head + mac_offset) < 0) {
+        return 0;
+    }
+
+    unsigned int net_offset = mac_offset + ETH_HLEN;
+    __be16 h_proto = eth.h_proto;
+
+    // Handle VLAN tags
+    if (h_proto == htons(ETH_P_8021Q) || h_proto == htons(ETH_P_8021AD)) {
+        net_offset += VLAN_HLEN;
+        if (bpf_probe_read_kernel(&h_proto, sizeof(h_proto), skb_head + mac_offset + ETH_HLEN + 2) < 0) {
+            return 0;
+        }
+        if (h_proto == htons(ETH_P_8021Q) || h_proto == htons(ETH_P_8021AD)) {
+             net_offset += VLAN_HLEN;
+             if (bpf_probe_read_kernel(&h_proto, sizeof(h_proto), skb_head + mac_offset + (2 * VLAN_HLEN) + 2) < 0) {
+                 return 0;
+             }
+        }
+    }
+
+    if (h_proto != htons(ETH_P_IP)) {
+        return 0;
+    }
+
+    struct iphdr ip;
+    if (bpf_probe_read_kernel(&ip, sizeof(ip), skb_head + net_offset) < 0) {
+        return 0;
+    }
+
+    key->src_ip = ip.saddr;
+    key->dst_ip = ip.daddr;
+    key->protocol = ip.protocol;
+
+    // Apply filters
+    if (PROTOCOL_FILTER != 0 && ip.protocol != PROTOCOL_FILTER) {
+        return 0;
+    }
+
+    // Apply IP filters
+    if (SRC_IP_FILTER != 0 && ip.saddr != SRC_IP_FILTER) {
+        return 0;
+    }
+    if (DST_IP_FILTER != 0 && ip.daddr != DST_IP_FILTER) {
+        return 0;
+    }
+
+    u8 ip_ihl = ip.ihl & 0x0F;
+    if (ip_ihl < 5) {
+        return 0;
+    }
+
+    unsigned int trans_offset = net_offset + (ip_ihl * 4);
+
+    // Parse transport layer
+    switch (ip.protocol) {
+        case IPPROTO_TCP: {
+            struct tcphdr tcp;
+            if (bpf_probe_read_kernel(&tcp, sizeof(tcp), skb_head + trans_offset) < 0) {
+                return 0;
+            }
+            key->tcp.src_port = tcp.source;
+            key->tcp.dst_port = tcp.dest;
+            key->tcp.seq = tcp.seq;
+
+            if (SRC_PORT_FILTER != 0 && key->tcp.src_port != htons(SRC_PORT_FILTER) && key->tcp.dst_port != htons(SRC_PORT_FILTER)) {
+                return 0;
+            }
+            if (DST_PORT_FILTER != 0 && key->tcp.src_port != htons(DST_PORT_FILTER) && key->tcp.dst_port != htons(DST_PORT_FILTER)) {
+                return 0;
+            }
+            break;
+        }
+        case IPPROTO_UDP: {
+            key->udp.ip_id = ip.id;
+
+            u16 frag_off_flags = ntohs(ip.frag_off);
+            u8 more_frag = (frag_off_flags & 0x2000) ? 1 : 0;
+            u16 frag_offset = frag_off_flags & 0x1FFF;
+            u8 is_fragment = (more_frag || frag_offset) ? 1 : 0;
+
+            if (is_fragment) {
+                key->udp.frag_off = frag_offset * 8;
+                if (frag_offset == 0) {
+                    struct udphdr udp;
+                    if (bpf_probe_read_kernel(&udp, sizeof(udp), skb_head + trans_offset) == 0) {
+                        key->udp.src_port = udp.source;
+                        key->udp.dst_port = udp.dest;
+                    } else {
+                        key->udp.src_port = 0;
+                        key->udp.dst_port = 0;
+                    }
+                } else {
+                    key->udp.src_port = 0;
+                    key->udp.dst_port = 0;
+                }
+            } else {
+                key->udp.frag_off = 0;
+                struct udphdr udp;
+                if (bpf_probe_read_kernel(&udp, sizeof(udp), skb_head + trans_offset) < 0) {
+                    return 0;
+                }
+                key->udp.src_port = udp.source;
+                key->udp.dst_port = udp.dest;
+            }
+
+            if (!is_fragment || frag_offset == 0) {
+                if (SRC_PORT_FILTER != 0 && key->udp.src_port != htons(SRC_PORT_FILTER) && key->udp.dst_port != htons(SRC_PORT_FILTER)) {
+                    return 0;
+                }
+                if (DST_PORT_FILTER != 0 && key->udp.src_port != htons(DST_PORT_FILTER) && key->udp.dst_port != htons(DST_PORT_FILTER)) {
+                    return 0;
+                }
+            }
+
+            break;
+        }
+        default:
+            return 0;
+    }
+
+    return 1;
+}
+
+static __always_inline int parse_packet_key(
+    struct sk_buff *skb,
+    struct packet_key_t *key,
+    u8 stage_id,
+    u8 direction
+) {
+    struct iphdr ip;
+    if (get_ip_header(skb, &ip, stage_id) != 0) {
+        return 0;
+    }
+
+    key->src_ip = ip.saddr;
+    key->dst_ip = ip.daddr;
+    key->protocol = ip.protocol;
+
+    if (PROTOCOL_FILTER != 0 && ip.protocol != PROTOCOL_FILTER) {
+        return 0;
+    }
+
+    // Apply IP filters
+    if (SRC_IP_FILTER != 0 && ip.saddr != SRC_IP_FILTER) {
+        return 0;
+    }
+    if (DST_IP_FILTER != 0 && ip.daddr != DST_IP_FILTER) {
+        return 0;
+    }
+
+    switch (ip.protocol) {
+        case IPPROTO_TCP:
+            if (!parse_tcp_key(skb, key, stage_id)) return 0;
+            if (SRC_PORT_FILTER != 0 && key->tcp.src_port != htons(SRC_PORT_FILTER) && key->tcp.dst_port != htons(SRC_PORT_FILTER)) {
+                return 0;
+            }
+            if (DST_PORT_FILTER != 0 && key->tcp.src_port != htons(DST_PORT_FILTER) && key->tcp.dst_port != htons(DST_PORT_FILTER)) {
+                return 0;
+            }
+            break;
+        case IPPROTO_UDP:
+            if (!parse_udp_key(skb, key, stage_id)) return 0;
+            if (key->udp.frag_off == 0) {
+                if (SRC_PORT_FILTER != 0 && key->udp.src_port != htons(SRC_PORT_FILTER) && key->udp.dst_port != htons(SRC_PORT_FILTER)) {
+                    return 0;
+                }
+                if (DST_PORT_FILTER != 0 && key->udp.src_port != htons(DST_PORT_FILTER) && key->udp.dst_port != htons(DST_PORT_FILTER)) {
+                    return 0;
+                }
+            }
+            break;
+        default:
+            return 0;
+    }
+
+    return 1;
+}
+
+// TCP early stage parsing - from __ip_queue_xmit with sock parameter
+static __always_inline int parse_packet_key_tcp_early(
+    struct sk_buff *skb,
+    struct sock *sk,
+    struct packet_key_t *key,
+    u8 stage_id
+) {
+    if (!sk) return 0;
+
+    // Get from socket
+    struct inet_sock *inet = (struct inet_sock *)sk;
+    bpf_probe_read_kernel(&key->src_ip, sizeof(key->src_ip), &inet->inet_saddr);
+    bpf_probe_read_kernel(&key->dst_ip, sizeof(key->dst_ip), &inet->inet_daddr);
+    bpf_probe_read_kernel(&key->tcp.src_port, sizeof(key->tcp.src_port), &inet->inet_sport);
+    bpf_probe_read_kernel(&key->tcp.dst_port, sizeof(key->tcp.dst_port), &inet->inet_dport);
+
+    key->protocol = IPPROTO_TCP;
+
+    // Apply filters
+    if (PROTOCOL_FILTER != 0 && key->protocol != PROTOCOL_FILTER) {
+        return 0;
+    }
+
+    if (SRC_IP_FILTER != 0 && key->src_ip != SRC_IP_FILTER) {
+        return 0;
+    }
+    if (DST_IP_FILTER != 0 && key->dst_ip != DST_IP_FILTER) {
+        return 0;
+    }
+
+    // Get TCP sequence number
+    struct tcp_sock *tp = (struct tcp_sock *)sk;
+    u32 tcp_snd_nxt = 0;
+    u32 tcp_write_seq = 0;
+
+    int snd_nxt_ret = bpf_probe_read_kernel(&tcp_snd_nxt, sizeof(tcp_snd_nxt), &tp->snd_nxt);
+    int write_seq_ret = bpf_probe_read_kernel(&tcp_write_seq, sizeof(tcp_write_seq), &tp->write_seq);
+
+    if (snd_nxt_ret >= 0 && tcp_snd_nxt != 0) {
+        key->tcp.seq = htonl(tcp_snd_nxt);
+    } else if (write_seq_ret >= 0 && tcp_write_seq != 0) {
+        key->tcp.seq = htonl(tcp_write_seq);
+    } else {
+        // Fallback: try from SKB data
+        unsigned char *data;
+        if (bpf_probe_read_kernel(&data, sizeof(data), &skb->data) >= 0 && data) {
+            struct iphdr ip;
+            if (bpf_probe_read_kernel(&ip, sizeof(ip), data) >= 0) {
+                u8 ip_ihl = (ip.ihl & 0x0F);
+                if (ip_ihl >= 5) {
+                    struct tcphdr tcp;
+                    if (bpf_probe_read_kernel(&tcp, sizeof(tcp), data + (ip_ihl * 4)) >= 0) {
+                        key->tcp.seq = tcp.seq;
+                    }
+                }
+            }
+        }
+    }
+
+    // Apply port filters
+    if (SRC_PORT_FILTER != 0 && key->tcp.src_port != htons(SRC_PORT_FILTER) && key->tcp.dst_port != htons(SRC_PORT_FILTER)) {
+        return 0;
+    }
+    if (DST_PORT_FILTER != 0 && key->tcp.src_port != htons(DST_PORT_FILTER) && key->tcp.dst_port != htons(DST_PORT_FILTER)) {
+        return 0;
+    }
+
+    return 1;
+}
+
+// Main event handling function - adjacent stage tracking only
+static __always_inline void handle_stage_event(void *ctx, struct sk_buff *skb, u8 stage_id, u8 direction) {
+    struct packet_key_t key = {};
+    u64 current_ts = bpf_ktime_get_ns();
+
+    // Parse packet key
+    int parse_success = 0;
+    if (stage_id == TX_STAGE_4 || stage_id == RX_STAGE_4) {
+        parse_success = parse_packet_key_userspace(skb, &key, stage_id, direction);
+    } else {
+        parse_success = parse_packet_key(skb, &key, stage_id, direction);
+    }
+
+    if (!parse_success) {
+        return;
+    }
+
+    // Check if this is the first stage for this direction
+    bool is_first_stage = false;
+    if ((direction == 1 && stage_id == TX_STAGE_0) ||
+        (direction == 2 && stage_id == RX_STAGE_0)) {
+        is_first_stage = true;
+    }
+
+    struct flow_data_t *flow_ptr;
+
+    if (is_first_stage) {
+        // Initialize new flow tracking
+        struct flow_data_t zero = {};
+        zero.direction = direction;
+        zero.last_stage = stage_id;
+        zero.last_timestamp = current_ts;
+        zero.first_timestamp = current_ts;
+
+        flow_sessions.delete(&key);
+        flow_ptr = flow_sessions.lookup_or_try_init(&key, &zero);
+
+        if (flow_ptr) {
+            u32 idx = direction;
+            u64 *counter = packet_counters.lookup(&idx);
+            if (counter) (*counter)++;
+
+            // Count first stage
+            u32 first_stage_idx = (direction == 1) ? 0 : 2;
+            u64 *first_counter = flow_stage_counters.lookup(&first_stage_idx);
+            if (first_counter) (*first_counter)++;
+        }
+        return;
+    } else {
+        flow_ptr = flow_sessions.lookup(&key);
+    }
+
+    if (!flow_ptr) {
+        flow_sessions.delete(&key);
+        return;
+    }
+
+    // Calculate and submit latency for adjacent stages
+    // Check last_timestamp > 0 to ensure there's a previous stage
+    // Note: last_stage can be 0 (TX_STAGE_0), so we check timestamp instead
+    if (flow_ptr->last_timestamp > 0 && flow_ptr->last_timestamp < current_ts) {
+        u64 prev_ts = flow_ptr->last_timestamp;
+        u64 latency_ns = current_ts - prev_ts;
+        u64 latency_us = latency_ns / 1000;
+
+        // Create stage pair key with latency bucket
+        struct stage_pair_key_t pair_key = {};
+        pair_key.prev_stage = flow_ptr->last_stage;
+        pair_key.curr_stage = stage_id;
+        pair_key.direction = direction;
+        pair_key.latency_bucket = bpf_log2l(latency_us + 1);
+
+        // Update histogram
+        adjacent_latency_hist.increment(pair_key, 1);
+    }
+
+    // Update tracking for next stage
+    flow_ptr->last_stage = stage_id;
+    flow_ptr->last_timestamp = current_ts;
+
+    // Check if this is the last stage
+    bool is_last_stage = false;
+    if ((direction == 1 && stage_id == TX_STAGE_6) ||
+        (direction == 2 && stage_id == RX_STAGE_6)) {
+        is_last_stage = true;
+
+        // Calculate total latency from first to last stage
+        if (flow_ptr->first_timestamp > 0 && current_ts > flow_ptr->first_timestamp) {
+            u64 total_latency = current_ts - flow_ptr->first_timestamp;
+
+            // Convert to microseconds and calculate log2 bucket
+            u64 latency_us = total_latency / 1000;
+            if (latency_us > 0) {
+                u8 log2_latency = bpf_log2l(latency_us);
+                total_latency_hist.increment(log2_latency);
+            }
+        }
+
+        // Count last stage
+        u32 last_stage_idx = (direction == 1) ? 1 : 3;
+        u64 *last_counter = flow_stage_counters.lookup(&last_stage_idx);
+        if (last_counter) (*last_counter)++;
+
+        // Delete flow session
+        flow_sessions.delete(&key);
+    }
+}
+
+// TX Stage 0: TCP __ip_queue_xmit - with special parsing
+static __always_inline void handle_stage_event_tcp_early(
+    void *ctx,
+    struct sock *sk,
+    struct sk_buff *skb,
+    u8 stage_id,
+    u8 direction
+) {
+    struct packet_key_t key = {};
+    if (!parse_packet_key_tcp_early(skb, sk, &key, stage_id)) {
+        return;
+    }
+
+    u64 current_ts = bpf_ktime_get_ns();
+
+    // Initialize flow (TX_STAGE_0 is first stage)
+    struct flow_data_t zero = {};
+    zero.direction = direction;
+    zero.last_stage = stage_id;
+    zero.last_timestamp = current_ts;
+    zero.first_timestamp = current_ts;
+
+    flow_sessions.delete(&key);
+    struct flow_data_t *flow_ptr = flow_sessions.lookup_or_try_init(&key, &zero);
+
+    if (flow_ptr) {
+        u32 idx = direction;
+        u64 *counter = packet_counters.lookup(&idx);
+        if (counter) (*counter)++;
+
+        // Count first stage
+        u32 first_stage_idx = (direction == 1) ? 0 : 2;
+        u64 *first_counter = flow_stage_counters.lookup(&first_stage_idx);
+        if (first_counter) (*first_counter)++;
+    }
+}
+
+// ========== Probe Points - from system_network_latency_details.py ==========
+
+// TX Stage 0: TCP __ip_queue_xmit
+int kprobe____ip_queue_xmit(struct pt_regs *ctx, struct sock *sk, struct sk_buff *skb, struct flowi *fl) {
+    if (DIRECTION_FILTER == 2) return 0;  // rx only
+    if (PROTOCOL_FILTER != 0 && PROTOCOL_FILTER != IPPROTO_TCP) return 0;
+
+    handle_stage_event_tcp_early(ctx, sk, skb, TX_STAGE_0, 1);
+    return 0;
+}
+
+// TX Stage 0: UDP ip_send_skb
+int kprobe__ip_send_skb(struct pt_regs *ctx, struct net *net, struct sk_buff *skb) {
+    if (DIRECTION_FILTER == 2) return 0;  // rx only
+    if (PROTOCOL_FILTER != 0 && PROTOCOL_FILTER != IPPROTO_UDP) return 0;
+
+    handle_stage_event(ctx, skb, TX_STAGE_0, 1);
+    return 0;
+}
+
+// TX Stage 1: internal_dev_xmit
+int kprobe__internal_dev_xmit(struct pt_regs *ctx, struct sk_buff *skb) {
+    if (DIRECTION_FILTER == 2) return 0;  // rx only
+    handle_stage_event(ctx, skb, TX_STAGE_1, 1);
+    return 0;
+}
+
+// OVS processing stages (common for TX/RX)
+int kprobe__ovs_dp_process_packet(struct pt_regs *ctx, const struct sk_buff *skb_const) {
+    struct sk_buff *skb = (struct sk_buff *)skb_const;
+    if (DIRECTION_FILTER != 2) {
+        handle_stage_event(ctx, skb, TX_STAGE_2, 1);
+    }
+    if (DIRECTION_FILTER != 1) {
+        handle_stage_event(ctx, skb, RX_STAGE_2, 2);
+    }
+    return 0;
+}
+
+int kprobe__ovs_dp_upcall(struct pt_regs *ctx, void *dp, const struct sk_buff *skb_const) {
+    struct sk_buff *skb = (struct sk_buff *)skb_const;
+    if (DIRECTION_FILTER != 2) {
+        handle_stage_event(ctx, skb, TX_STAGE_3, 1);
+    }
+    if (DIRECTION_FILTER != 1) {
+        handle_stage_event(ctx, skb, RX_STAGE_3, 2);
+    }
+    return 0;
+}
+
+int kprobe__ovs_flow_key_extract_userspace(struct pt_regs *ctx, struct net *net, const struct nlattr *attr, struct sk_buff *skb) {
+    if (!skb) return 0;
+    if (DIRECTION_FILTER != 2) {
+        handle_stage_event(ctx, skb, TX_STAGE_4, 1);
+    }
+    if (DIRECTION_FILTER != 1) {
+        handle_stage_event(ctx, skb, RX_STAGE_4, 2);
+    }
+    return 0;
+}
+
+int kprobe__ovs_vport_send(struct pt_regs *ctx, const void *vport, struct sk_buff *skb) {
+    if (DIRECTION_FILTER != 2) {
+        handle_stage_event(ctx, skb, TX_STAGE_5, 1);
+    }
+    if (DIRECTION_FILTER != 1) {
+        handle_stage_event(ctx, skb, RX_STAGE_5, 2);
+    }
+    return 0;
+}
+
+// TX Stage 6: dev_queue_xmit
+int kprobe__dev_queue_xmit(struct pt_regs *ctx, struct sk_buff *skb) {
+    if (!is_target_ifindex(skb)) return 0;
+    if (DIRECTION_FILTER == 2) return 0;  // rx only
+    handle_stage_event(ctx, skb, TX_STAGE_6, 1);
+    return 0;
+}
+
+// RX Stage 0: netif_receive_skb tracepoint
+TRACEPOINT_PROBE(net, netif_receive_skb) {
+    struct sk_buff *skb = (struct sk_buff *)args->skbaddr;
+    if (!skb) return 0;
+
+    if (!is_target_ifindex(skb)) return 0;
+    if (DIRECTION_FILTER == 1) return 0;  // tx only
+
+    handle_stage_event(args, skb, RX_STAGE_0, 2);
+    return 0;
+}
+
+// RX Stage 1: netdev_frame_hook
+int kprobe__netdev_frame_hook(struct pt_regs *ctx, struct sk_buff **pskb) {
+    struct sk_buff *skb = NULL;
+    if (bpf_probe_read_kernel(&skb, sizeof(skb), pskb) < 0 || skb == NULL) {
+        return 0;
+    }
+
+    if (DIRECTION_FILTER != 1) {
+        handle_stage_event(ctx, skb, RX_STAGE_1, 2);
+    }
+    return 0;
+}
+
+// RX Stage 6: tcp_v4_rcv
+int kprobe__tcp_v4_rcv(struct pt_regs *ctx, struct sk_buff *skb) {
+    if (DIRECTION_FILTER == 1) return 0;  // tx only
+    if (PROTOCOL_FILTER != 0 && PROTOCOL_FILTER != IPPROTO_TCP) return 0;
+    handle_stage_event(ctx, skb, RX_STAGE_6, 2);
+    return 0;
+}
+
+// RX Stage 6: __udp4_lib_rcv
+int kprobe____udp4_lib_rcv(struct pt_regs *ctx, struct sk_buff *skb, struct udp_table *udptable) {
+    if (DIRECTION_FILTER == 1) return 0;  // tx only
+    if (PROTOCOL_FILTER != 0 && PROTOCOL_FILTER != IPPROTO_UDP) return 0;
+    handle_stage_event(ctx, skb, RX_STAGE_6, 2);
+    return 0;
+}
+
+"""
+
+# Constants
+MAX_STAGES = 14
+
+# Helper Functions
+def get_if_index(devname):
+    """Get the interface index for a device name"""
+    SIOCGIFINDEX = 0x8933
+    if len(devname.encode('ascii')) > 15:
+        raise OSError("Interface name '%s' too long" % devname)
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, 0)
+    buf = struct.pack('16s%dx' % (256-16), devname.encode('ascii'))
+    try:
+        res = fcntl.ioctl(s.fileno(), SIOCGIFINDEX, buf)
+        idx = struct.unpack('I', res[16:20])[0]
+        return idx
+    except IOError as e:
+        raise OSError("ioctl failed for interface '%s': %s" % (devname, e))
+    finally:
+        s.close()
+
+def ip_to_hex(ip_str):
+    """Convert IP string to network-ordered hex value"""
+    if not ip_str or ip_str == "0.0.0.0":
+        return 0
+    try:
+        packed_ip = socket.inet_aton(ip_str)
+        host_int = struct.unpack("!I", packed_ip)[0]
+        return socket.htonl(host_int)
+    except socket.error:
+        print("Error: Invalid IP address format '%s'" % ip_str)
+        sys.exit(1)
+
+def format_ip(addr):
+    """Format integer IP address to string"""
+    return socket.inet_ntop(socket.AF_INET, struct.pack("=I", addr))
+
+def get_stage_name(stage_id):
+    """Get human-readable stage name"""
+    stage_names = {
+        # TX path
+        0: "TX_S0_ip_layer_entry",
+        1: "TX_S1_internal_dev_xmit",
+        2: "TX_S2_ovs_dp_process",
+        3: "TX_S3_ovs_dp_upcall",
+        4: "TX_S4_ovs_flow_key_extract",
+        5: "TX_S5_ovs_vport_send",
+        6: "TX_S6_dev_queue_xmit",
+
+        # RX path
+        7: "RX_S0_netif_receive_skb",
+        8: "RX_S1_netdev_frame_hook",
+        9: "RX_S2_ovs_dp_process",
+        10: "RX_S3_ovs_dp_upcall",
+        11: "RX_S4_ovs_flow_key_extract",
+        12: "RX_S5_ovs_vport_send",
+        13: "RX_S6_tcp_v4_rcv/udp_rcv"
+    }
+    return stage_names.get(stage_id, "UNKNOWN_%d" % stage_id)
+
+def print_histogram_summary(b, interval_start_time):
+    """Print histogram summary for the current interval"""
+    current_time = datetime.datetime.now()
+    print("\n" + "=" * 80)
+    print("[%s] System Network Latency Report (Interval: %.1fs)" % (
+        current_time.strftime("%Y-%m-%d %H:%M:%S"),
+        time_time() - interval_start_time
+    ))
+    print("=" * 80)
+
+    # Get stage pair histogram data
+    latency_hist = b["adjacent_latency_hist"]
+
+    # Collect all stage pair data organized by (prev_stage, curr_stage, direction)
+    stage_pair_data = {}
+
+    try:
+        for k, v in latency_hist.items():
+            pair_key = (k.prev_stage, k.curr_stage, k.direction)
+            bucket = k.latency_bucket
+            count = v.value if hasattr(v, 'value') else int(v)
+
+            if pair_key not in stage_pair_data:
+                stage_pair_data[pair_key] = {}
+            stage_pair_data[pair_key][bucket] = count
+    except Exception as e:
+        print("Error reading histogram data:", str(e))
+        return
+
+    if not stage_pair_data:
+        print("No adjacent stage data collected in this interval")
+        return
+
+    print("Found %d unique stage pairs" % len(stage_pair_data))
+
+    # Sort stage pairs by direction, then by stages
+    sorted_pairs = sorted(stage_pair_data.keys(), key=lambda x: (x[2], x[0], x[1]))
+
+    # Print by direction
+    for direction in [1, 2]:
+        dir_pairs = [p for p in sorted_pairs if p[2] == direction]
+        if not dir_pairs:
+            continue
+
+        direction_str = "TX Direction (System -> Physical)" if direction == 1 else "RX Direction (Physical -> System)"
+        print("\n%s:" % direction_str)
+        print("-" * 60)
+
+        for prev_stage, curr_stage, dir_val in dir_pairs:
+            prev_name = get_stage_name(prev_stage)
+            curr_name = get_stage_name(curr_stage)
+
+            print("\n  %s -> %s:" % (prev_name, curr_name))
+
+            # Get histogram data for this stage pair
+            buckets = stage_pair_data[(prev_stage, curr_stage, dir_val)]
+            total_samples = sum(buckets.values())
+
+            if total_samples == 0:
+                print("    No samples")
+                continue
+
+            print("    Total samples: %d" % total_samples)
+            print("    Latency distribution:")
+
+            # Sort buckets and display
+            sorted_buckets = sorted(buckets.items())
+            max_count = max(buckets.values())
+
+            for bucket, count in sorted_buckets:
+                if count > 0:
+                    # Convert bucket to latency range
+                    if bucket == 0:
+                        range_str = "0-1us"
+                    else:
+                        low = 1 << (bucket - 1)
+                        high = (1 << bucket) - 1
+                        range_str = "%d-%dus" % (low, high)
+
+                    # Create simple bar graph
+                    bar_width = int(40 * count / max_count)
+                    bar = "*" * bar_width
+
+                    print("      %-12s: %6d |%-40s|" % (range_str, count, bar))
+
+    # Print packet counters
+    counters = b["packet_counters"]
+    print("\nPacket Counters:")
+    print("  TX packets: %d" % counters[1].value)
+    print("  RX packets: %d" % counters[2].value)
+
+    # Calculate incomplete flows
+    flow_counters = b["flow_stage_counters"]
+
+    first_stage_tx = flow_counters[0].value
+    last_stage_tx = flow_counters[1].value
+    first_stage_rx = flow_counters[2].value
+    last_stage_rx = flow_counters[3].value
+
+    incomplete_tx_count = first_stage_tx - last_stage_tx
+    incomplete_rx_count = first_stage_rx - last_stage_rx
+
+    print("\nFlow Session Analysis:")
+    if first_stage_tx > 0:
+        print("  TX started: %d, completed: %d, incomplete: %d (%.2f%%)" % (
+            first_stage_tx, last_stage_tx, incomplete_tx_count,
+            100.0 * incomplete_tx_count / first_stage_tx if first_stage_tx > 0 else 0))
+    if first_stage_rx > 0:
+        print("  RX started: %d, completed: %d, incomplete: %d (%.2f%%)" % (
+            first_stage_rx, last_stage_rx, incomplete_rx_count,
+            100.0 * incomplete_rx_count / first_stage_rx if first_stage_rx > 0 else 0))
+
+    # Check active flows
+    total_active_flows = 0
+    try:
+        flow_sessions = b["flow_sessions"]
+        total_active_flows = len(flow_sessions)
+    except:
+        total_active_flows = -1
+
+    if total_active_flows >= 0:
+        print("  Currently active flow sessions: %d" % total_active_flows)
+
+    # Display total latency histogram
+    print("\nTotal End-to-End Latency Distribution:")
+    print("-" * 60)
+
+    try:
+        total_hist = b["total_latency_hist"]
+        total_latency_data = {}
+
+        for k, v in total_hist.items():
+            bucket = k.value if hasattr(k, 'value') else int(k)
+            count = v.value if hasattr(v, 'value') else int(v)
+            if count > 0:
+                total_latency_data[bucket] = count
+
+        if total_latency_data:
+            max_count = max(total_latency_data.values())
+
+            for bucket in sorted(total_latency_data.keys()):
+                count = total_latency_data[bucket]
+
+                if bucket == 0:
+                    range_str = "1us"
+                else:
+                    low = 1 << (bucket - 1)
+                    high = (1 << bucket) - 1
+                    range_str = "%d-%dus" % (low, high)
+
+                bar_width = int(40 * count / max_count)
+                bar = "*" * bar_width
+
+                print("  %-12s: %6d |%-40s|" % (range_str, count, bar))
+        else:
+            print("  No total latency data collected in this interval")
+    except Exception as e:
+        print("  Error reading total latency histogram: %s" % str(e))
+
+    # Clear histograms for next interval
+    latency_hist.clear()
+    try:
+        total_hist = b["total_latency_hist"]
+        total_hist.clear()
+    except:
+        pass
+
+def main():
+    global direction_filter
+
+    if os.geteuid() != 0:
+        print("This program must be run as root")
+        sys.exit(1)
+
+    parser = argparse.ArgumentParser(
+        description="System Network Adjacent Stage Latency Histogram Tool",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  Monitor TCP TX traffic (packets leaving system):
+    sudo %(prog)s --phy-interface enp94s0f0np0 --direction tx --protocol tcp --src-ip 70.0.0.33
+
+  Monitor UDP RX traffic (packets entering system):
+    sudo %(prog)s --phy-interface enp94s0f0np0 --direction rx --protocol udp --dst-ip 70.0.0.33
+
+  Monitor all TCP/UDP traffic with 10 second intervals:
+    sudo %(prog)s --phy-interface enp94s0f0np0 --direction tx --protocol all --interval 10
+"""
+    )
+
+    parser.add_argument('--phy-interface', type=str, required=True,
+                        help='Physical interface to monitor (e.g., enp94s0f0np0)')
+    parser.add_argument('--src-ip', type=str, required=False,
+                        help='Source IP address filter')
+    parser.add_argument('--dst-ip', type=str, required=False,
+                        help='Destination IP address filter')
+    parser.add_argument('--src-port', type=int, required=False,
+                        help='Source port filter (TCP/UDP)')
+    parser.add_argument('--dst-port', type=int, required=False,
+                        help='Destination port filter (TCP/UDP)')
+    parser.add_argument('--protocol', type=str, choices=['tcp', 'udp', 'all'],
+                        default='all', help='Protocol filter (default: all)')
+    parser.add_argument('--direction', type=str, choices=['tx', 'rx'],
+                        required=True, help='Direction filter: tx=System TX, rx=System RX')
+    parser.add_argument('--interval', type=int, default=5,
+                        help='Statistics output interval in seconds (default: 5)')
+
+    args = parser.parse_args()
+
+    # Convert parameters
+    src_ip_hex = ip_to_hex(args.src_ip) if args.src_ip else 0
+    dst_ip_hex = ip_to_hex(args.dst_ip) if args.dst_ip else 0
+    src_port = args.src_port if args.src_port else 0
+    dst_port = args.dst_port if args.dst_port else 0
+
+    protocol_map = {'tcp': 6, 'udp': 17, 'all': 0}
+    protocol_filter = protocol_map[args.protocol]
+
+    # Direction: 1=tx, 2=rx
+    direction_map = {'tx': 1, 'rx': 2}
+    direction_filter = direction_map[args.direction]
+
+    # Support multiple interfaces
+    phy_interfaces = args.phy_interface.split(',')
+    try:
+        ifindex1 = get_if_index(phy_interfaces[0].strip())
+        ifindex2 = get_if_index(phy_interfaces[1].strip()) if len(phy_interfaces) > 1 else ifindex1
+    except OSError as e:
+        print("Error getting interface index: %s" % e)
+        sys.exit(1)
+
+    print("=== System Network Adjacent Stage Latency Histogram Tool ===")
+    print("Protocol filter: %s" % args.protocol.upper())
+    print("Direction filter: %s (tx=System->Physical, rx=Physical->System)" % args.direction.upper())
+    if args.src_ip:
+        print("Source IP filter: %s" % args.src_ip)
+    if args.dst_ip:
+        print("Destination IP filter: %s" % args.dst_ip)
+    if src_port:
+        print("Source port filter: %d" % src_port)
+    if dst_port:
+        print("Destination port filter: %d" % dst_port)
+    print("Physical interfaces: %s (ifindex %d, %d)" % (args.phy_interface, ifindex1, ifindex2))
+    print("Statistics interval: %d seconds" % args.interval)
+    print("Mode: Adjacent stage latency tracking only")
+
+    try:
+        b = BPF(text=bpf_text % (
+            src_ip_hex, dst_ip_hex, src_port, dst_port,
+            protocol_filter, ifindex1, ifindex2, direction_filter
+        ))
+        print("BPF program loaded successfully")
+    except Exception as e:
+        print("Error loading BPF program: %s" % e)
+        sys.exit(1)
+
+    print("\nCollecting adjacent stage latency data... Hit Ctrl-C to end.")
+    print("Statistics will be displayed every %d seconds\n" % args.interval)
+
+    # Setup signal handler for clean exit
+    def signal_handler(sig, frame):
+        print("\n\nFinal statistics:")
+        print_histogram_summary(b, interval_start_time)
+        print("\nExiting...")
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, signal_handler)
+
+    # Main loop
+    interval_start_time = time_time()
+
+    try:
+        while True:
+            sleep(args.interval)
+            print_histogram_summary(b, interval_start_time)
+            interval_start_time = time_time()
+    except KeyboardInterrupt:
+        pass
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
…tools

- Add kernel_icmp_rtt.py: simplified ICMP RTT tracer for kernel stack without OVS layer, using ip_local_out/dev_queue_xmit probes
- Add system_network_latency_summary.py: histogram-based tool for measuring latency distribution between adjacent network stack stages
- Refactor system_network_icmp_rtt.py:
  - Switch from ip_send_skb to ip_output hook for better compatibility
  - Use TRACEPOINT_PROBE instead of RAW_TRACEPOINT_PROBE
  - Remove unused includes and debug trace comments
  - Fix indentation and whitespace issues